### PR TITLE
De-mock CLI tests

### DIFF
--- a/lxdock/cli/main.py
+++ b/lxdock/cli/main.py
@@ -12,10 +12,10 @@ from .exceptions import CLIError
 logger = logging.getLogger(__name__)
 
 
-class LXDock(object):
+class LXDock:
     """ Wrapper around the LXDock argument parser and the related actions. """
 
-    def __init__(self):
+    def __init__(self, argv=None):
         self._parsers = {}
 
         # Creates the argument parsers
@@ -90,7 +90,7 @@ class LXDock(object):
             self._parsers[pkey].add_argument('name', nargs='*', help='Container name.')
 
         # Parses the arguments
-        args = parser.parse_args()
+        args = parser.parse_args(args=argv)
 
         # Displays the help if no action is specified
         if args.action is None:
@@ -193,7 +193,7 @@ class LXDock(object):
         return self._project_config
 
 
-def main():
+def main(argv=None):
     # Setup logging
     root_logger = logging.getLogger()
     root_logger.addHandler(console_stdout_handler)
@@ -204,4 +204,4 @@ def main():
     logging.getLogger('ws4py').propagate = False
 
     # Run the LXDock orchestration tool!
-    LXDock()
+    LXDock(argv=argv)

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 import unittest.mock
 
@@ -16,323 +15,234 @@ from lxdock.project import Project
 FIXTURE_ROOT = os.path.join(os.path.dirname(__file__), 'fixtures')
 
 
-def _gen_argparse_namespace(**kwargs):
-    default_options = {
-        'action': None,
-        'force': False,
-        'name': None,
-        'subcommand': None,
-        'verbose': False,
-        'username': None,
-    }
-    default_options.update(kwargs)
-    return argparse.Namespace(**default_options)
-
-
-@unittest.mock.patch(
-    'argparse.ArgumentParser.parse_args', return_value=_gen_argparse_namespace(action='help'))
 @unittest.mock.patch.object(LXDock, 'help')
-def test_main_function_can_run_a_lxdock_command(mock_help_action, mock_parse_args):
-    main()
+def test_main_function_can_run_a_lxdock_command(mock_help_action):
+    main(['help'])
     assert mock_help_action.call_count == 1
 
 
 class TestLXDock:
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='config', containers=False))
     @unittest.mock.patch.object(LXDock, 'project_config')
     @unittest.mock.patch.object(Config, 'serialize')
-    def test_can_display_the_config_file_of_the_project(
-            self, serialize_mock, mock_config, mock_parse_args):
+    def test_can_display_the_config_file_of_the_project(self, serialize_mock, mock_config):
         mock_config.__get__ = unittest.mock.Mock(
             return_value=Config.from_base_dir(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['config'])
         assert serialize_mock.call_count == 1
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='config', containers=True))
     @unittest.mock.patch.object(LXDock, 'project_config')
     @unittest.mock.patch.object(Config, 'serialize')
     def test_can_display_the_containers_of_the_config_file_of_the_project(
-            self, serialize_mock, mock_config, mock_parse_args):
+            self, serialize_mock, mock_config):
         mock_config.__get__ = unittest.mock.Mock(
             return_value=Config.from_base_dir(os.path.join(FIXTURE_ROOT, 'project01')))
-        n = LXDock()
+        argv = ['config', '--containers']
+        n = LXDock(argv)
         assert serialize_mock.call_count == 0
-        assert n._parsers['main'].parse_args().containers
+        assert n._parsers['main'].parse_args(argv).containers
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='destroy'))
     @unittest.mock.patch('builtins.input', return_value='Y')
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'destroy')
     @unittest.mock.patch.object(Container, 'exists')
     def test_can_run_the_destroy_action_for_all_containers_of_a_project(
-            self, container_exists_mock, mock_project_destroy, mock_project, y_mock,
-            mock_parse_args):
+            self, container_exists_mock, mock_project_destroy, mock_project, y_mock):
         container_exists_mock.__get__ = unittest.mock.Mock(return_value=True)
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['destroy'])
         assert mock_project_destroy.call_count == 1
-        assert mock_project_destroy.call_args == [{'container_names': None, }, ]
+        assert mock_project_destroy.call_args == [{'container_names': [], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='destroy', name=['default', ]))
     @unittest.mock.patch('builtins.input', return_value='Y')
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'destroy')
     @unittest.mock.patch.object(Container, 'exists')
     def test_can_run_the_destroy_action_for_specific_containers(
-            self, container_exists_mock, mock_project_destroy, mock_project, y_mock,
-            mock_parse_args):
+            self, container_exists_mock, mock_project_destroy, mock_project, y_mock):
         container_exists_mock.__get__ = unittest.mock.Mock(return_value=True)
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['destroy', 'default'])
         assert mock_project_destroy.call_count == 1
         assert mock_project_destroy.call_args == [{'container_names': ['default', ], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='destroy', force=True))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'destroy')
     @unittest.mock.patch.object(Container, 'exists')
     def test_can_run_the_destroy_containers_using_a_force_option(
-            self, container_exists_mock, mock_project_destroy, mock_project, mock_parse_args):
+            self, container_exists_mock, mock_project_destroy, mock_project):
         container_exists_mock.__get__ = unittest.mock.Mock(return_value=True)
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['destroy', '--force'])
         assert mock_project_destroy.call_count == 1
-        assert mock_project_destroy.call_args == [{'container_names': None, }, ]
+        assert mock_project_destroy.call_args == [{'container_names': [], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='destroy'))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'destroy')
     @unittest.mock.patch.object(Container, 'exists')
     def test_can_force_the_destroy_action_if_the_containers_do_not_exist(
-            self, container_exists_mock, mock_project_destroy, mock_project, mock_parse_args):
+            self, container_exists_mock, mock_project_destroy, mock_project):
         container_exists_mock.__get__ = unittest.mock.Mock(return_value=False)
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['destroy'])
         assert mock_project_destroy.call_count == 1
-        assert mock_project_destroy.call_args == [{'container_names': None, }, ]
+        assert mock_project_destroy.call_args == [{'container_names': [], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='halt'))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'halt')
     def test_can_run_the_halt_action_for_all_containers_of_a_project(
-            self, mock_project_halt, mock_project, mock_parse_args):
+            self, mock_project_halt, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['halt'])
         assert mock_project_halt.call_count == 1
-        assert mock_project_halt.call_args == [{'container_names': None, }, ]
+        assert mock_project_halt.call_args == [{'container_names': [], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='halt', name=['c1', 'c2', ]))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'halt')
     def test_can_run_the_halt_action_for_specific_containers(
-            self, mock_project_halt, mock_project, mock_parse_args):
+            self, mock_project_halt, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['halt', 'c1', 'c2'])
         assert mock_project_halt.call_count == 1
         assert mock_project_halt.call_args == [{'container_names': ['c1', 'c2', ], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='help'))
-    def test_can_print_the_global_help(self, mock_parse_args):
-        n = LXDock()
-        assert n._parsers['main'].parse_args().subcommand is None
+    def test_can_print_the_global_help(self):
+        argv = ['help']
+        n = LXDock(argv)
+        assert n._parsers['main'].parse_args(argv).subcommand is None
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='help', subcommand='up'))
-    def test_can_print_the_help_for_a_specific_subcommand(self, mock_parse_args):
-        n = LXDock()
-        assert n._parsers['main'].parse_args().subcommand == 'up'
+    def test_can_print_the_help_for_a_specific_subcommand(self):
+        argv = ['help', 'up']
+        n = LXDock(argv)
+        assert n._parsers['main'].parse_args(argv).subcommand == 'up'
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='provision'))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'provision')
     def test_can_run_the_provision_action_for_all_containers_of_a_project(
-            self, mock_project_provision, mock_project, mock_parse_args):
+            self, mock_project_provision, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['provision'])
         assert mock_project_provision.call_count == 1
-        assert mock_project_provision.call_args == [{'container_names': None, }, ]
+        assert mock_project_provision.call_args == [{'container_names': [], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='provision', name=['c1', 'c2', ]))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'provision')
     def test_can_run_the_provision_action_for_specific_containers(
-            self, mock_project_provision, mock_project, mock_parse_args):
+            self, mock_project_provision, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['provision', 'c1', 'c2'])
         assert mock_project_provision.call_count == 1
         assert mock_project_provision.call_args == [{'container_names': ['c1', 'c2', ], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='shell'))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'shell')
     def test_can_run_the_shell_action_for_all_containers_of_a_project(
-            self, mock_project_shell, mock_project, mock_parse_args):
+            self, mock_project_shell, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['shell'])
         assert mock_project_shell.call_count == 1
         assert mock_project_shell.call_args == [{'container_name': None, 'username': None}, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='shell', name=['c1', ]))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'shell')
     def test_can_run_the_shell_action_for_a_specific_container(
-            self, mock_project_shell, mock_project, mock_parse_args):
+            self, mock_project_shell, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['shell', 'c1'])
         assert mock_project_shell.call_count == 1
-        assert mock_project_shell.call_args == [{'container_name': ['c1', ], 'username': None}, ]
+        assert mock_project_shell.call_args == [{'container_name': 'c1', 'username': None}, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='shell', username='foobar'))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'shell')
-    def test_can_run_the_shell_action_for_a_specific_user(
-            self, mock_project_shell, mock_project, mock_parse_args):
+    def test_can_run_the_shell_action_for_a_specific_user(self, mock_project_shell, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['shell', '-u', 'foobar'])
         assert mock_project_shell.call_count == 1
         assert mock_project_shell.call_args == [{'container_name': None, 'username': 'foobar'}, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='status'))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'status')
     def test_can_run_the_status_action_for_all_containers_of_a_project(
-            self, mock_project_status, mock_project, mock_parse_args):
+            self, mock_project_status, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['status'])
         assert mock_project_status.call_count == 1
-        assert mock_project_status.call_args == [{'container_names': None, }, ]
+        assert mock_project_status.call_args == [{'container_names': [], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='status', name=['c1', 'c2', ]))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'status')
     def test_can_run_the_status_action_for_specific_containers(
-            self, mock_project_status, mock_project, mock_parse_args):
+            self, mock_project_status, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['status', 'c1', 'c2'])
         assert mock_project_status.call_count == 1
         assert mock_project_status.call_args == [{'container_names': ['c1', 'c2', ], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='up'))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'up')
     def test_can_run_the_up_action_for_all_containers_of_a_project(
-            self, mock_project_up, mock_project, mock_parse_args):
+            self, mock_project_up, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['up'])
         assert mock_project_up.call_count == 1
-        assert mock_project_up.call_args == [{'container_names': None, }, ]
+        assert mock_project_up.call_args == [{'container_names': [], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='up', name=['c1', 'c2', ], verbose=True))
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'up')
     def test_can_run_the_up_action_for_specific_containers(
-            self, mock_project_up, mock_project, mock_parse_args):
+            self, mock_project_up, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock()
+        LXDock(['up', 'c1', 'c2'])
         assert mock_project_up.call_count == 1
         assert mock_project_up.call_args == [{'container_names': ['c1', 'c2', ], }, ]
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace())
-    def test_exit_if_no_action_is_provided(self, mock_parse_args):
+    def test_exit_if_no_action_is_provided(self):
         with pytest.raises(SystemExit):
-            LXDock()
+            LXDock([])
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='help', subcommand='unknown'))
-    def test_exit_if_a_cli_error_is_encountered(self, mock_parse_args):
+    def test_exit_if_a_cli_error_is_encountered(self):
         with pytest.raises(SystemExit):
-            LXDock()
+            LXDock(['help', 'unknown'])
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args', return_value=_gen_argparse_namespace(action='up'))
     @unittest.mock.patch.object(LXDock, 'project')
-    def test_exit_if_a_config_error_is_encountered(self, mock_project, mock_parse_args):
+    def test_exit_if_a_config_error_is_encountered(self, mock_project):
         mock_project.__get__ = unittest.mock.Mock(side_effect=ConfigError(msg='TEST'))
         with pytest.raises(SystemExit):
-            LXDock()
+            LXDock(['up'])
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args', return_value=_gen_argparse_namespace(action='up'))
     @unittest.mock.patch.object(LXDock, 'project')
-    def test_exit_if_a_lxdock_error_is_encountered(self, mock_project, mock_parse_args):
+    def test_exit_if_a_lxdock_error_is_encountered(self, mock_project):
         mock_project.__get__ = unittest.mock.Mock(side_effect=LXDockException(msg='TEST'))
         with pytest.raises(SystemExit):
-            LXDock()
+            LXDock(['up'])
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='config', containers=False))
     @unittest.mock.patch.object(Config, 'from_base_dir')
     def test_project_config_property_works(
-            self, from_base_dir_mock, mock_parse_args):
-        n = LXDock()
+            self, from_base_dir_mock):
+        n = LXDock(['config'])
         config1, config2 = n.project_config, n.project_config
         assert config1 == config2
         assert from_base_dir_mock.call_count == 1
 
-    @unittest.mock.patch(
-        'argparse.ArgumentParser.parse_args',
-        return_value=_gen_argparse_namespace(action='config', containers=False))
     @unittest.mock.patch.object(Config, 'from_base_dir')
     @unittest.mock.patch.object(Project, 'from_config')
     def test_project_property_works(
-            self, from_config_mock, from_base_dir_mock, mock_parse_args):
-        n = LXDock()
+            self, from_config_mock, from_base_dir_mock):
+        n = LXDock(['config'])
         project1, project2 = n.project, n.project
         assert project1 == project2
         assert from_config_mock.call_count == 1


### PR DESCRIPTION
Remove `parse_args()` mocking from CLI tests and replace it with the
ability, in `LXDock()`, to override parsed args with arbitrary args.

This makes tests much less heavy and a little less tautological. It also
uncovered cases where mocked parsed args were actually wrong, making us
test the wrong `call_args`.