### PR TITLE
docs: improve pip3 installation notes

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -80,12 +80,9 @@ You should now be able to install LXDock using:
 
 .. note::
 
-  Don't have ``pip3`` installed on your system? Try this:
-
-  .. code-block:: console
-
-    $ sudo apt-get install curl
-    $ curl https://bootstrap.pypa.io/get-pip.py | sudo python3
+  Don't have ``pip3`` installed on your system? Most distros have a specific package for it, it's
+  only a matter of installing it. For example, on Debian and Ubuntu, it's ``python3-pip``.
+  Otherwise, `Stackoverflow can help you <http://stackoverflow.com/a/6587528>`__.
 
 Command line completion
 -----------------------


### PR DESCRIPTION
The manual installation of pip3 should be a last resort. It's not a good
idea to do this on a Debian/Ubuntu system, so we should not suggest it.
Also, stackoferflow has a better overall answer for edge cases.