### PR TITLE
docs: add "Problems?" section to "Getting Started"

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -133,6 +133,8 @@ This option can define the name of your project or the name of a container. In e
     - name: container01
     - name: container01
 
+.. _conf-privileged:
+
 privileged
 ----------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -157,3 +157,11 @@ Now from your project directory, start up your containers using the following co
   ==> test02: Provisioning container "test02"...
 
 *Congrats! You're in!*
+
+Problems?
+---------
+
+If you're having problems trying to run your container, try running them in :ref:`conf-privileged`
+mode. Many older distributions have an init system that doesn't work well with unprivileged
+containers (`debian/jessie` notably). Some host-side problems can also be worked around by running
+privileged containers.


### PR DESCRIPTION
The old readme had something about trying privileged mode when
encountering problems and this disappeared in the new docs. Considering
that `debian/jessie` is a popular image and that it doesn't work in
unprivileged mode, I think it's important to have that section to avoid
being swamped with troubleshooting issues of this type on github.