### PR TITLE
New: Add guests - Alpine, Centos, Fedora, Gentoo, OpenSUSE, Oracle. Closes #29.

### DIFF
--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -110,7 +110,7 @@ class Container:
             cmd = 'lxc exec {} {} -- su -m {}'.format(self.lxd_name, homearg, shelluser)
             subprocess.call(cmd, shell=True)
         else:
-            cmd = 'lxc exec {} -- bash'.format(self.lxd_name)
+            cmd = 'lxc exec {} -- su -m root'.format(self.lxd_name)
             subprocess.call(cmd, shell=True)
 
     def up(self):

--- a/lxdock/guests/__init__.py
+++ b/lxdock/guests/__init__.py
@@ -5,7 +5,13 @@
     side (the containers).
 """
 
+from .alpine import *     # noqa
 from .archlinux import *  # noqa
-from .base import *  # noqa
-from .debian import *  # noqa
-from .ubuntu import *  # noqa
+from .base import *       # noqa
+from .centos import *     # noqa
+from .debian import *     # noqa
+from .fedora import *     # noqa
+from .gentoo import *     # noqa
+from .opensuse import *   # noqa
+from .oracle import *     # noqa
+from .ubuntu import *     # noqa

--- a/lxdock/guests/alpine.py
+++ b/lxdock/guests/alpine.py
@@ -1,0 +1,18 @@
+from .base import Guest
+
+
+class AlpineGuest(Guest):
+    """ This guest can provision Alpine containers. """
+
+    name = 'alpine'
+    barebones_packages = [
+        'openssh',
+        'python',
+    ]
+
+    def install_barebones_packages(self):
+        """ Installs packages when the guest is first provisionned. """
+        self.run(['apk', 'update'])
+        self.run(['apk', 'add'] + self.barebones_packages)
+        self.run(['rc-update', 'add', 'sshd'])
+        self.run(['/etc/init.d/sshd', 'start'])

--- a/lxdock/guests/base.py
+++ b/lxdock/guests/base.py
@@ -88,8 +88,8 @@ class Guest(with_metaclass(_GuestBase)):
         the considered OS/distribution.
         """
         candidates = [
-            ('/etc/os-release', 'id="?{}"?'.format(cls.name.lower())),
-            ('/etc/lsb_release', 'id="?{}"?'.format(cls.name.lower())),
+            ('/etc/os-release', '(id|ID)="?{}"?'.format(cls.name.lower())),
+            ('/etc/lsb_release', '(id|ID)="?{}"?'.format(cls.name.lower())),
             ('/etc/issue', cls.name.lower()),
         ]
         found = False

--- a/lxdock/guests/centos.py
+++ b/lxdock/guests/centos.py
@@ -1,0 +1,15 @@
+from .base import Guest
+
+
+class CentosGuest(Guest):
+    """ This guest can provision Centos containers. """
+
+    name = 'centos'
+    barebones_packages = [
+        'openssh-server',
+        'python',
+    ]
+
+    def install_barebones_packages(self):
+        """ Installs packages when the guest is first provisionned. """
+        self.run(['yum', '-y', 'install'] + self.barebones_packages)

--- a/lxdock/guests/fedora.py
+++ b/lxdock/guests/fedora.py
@@ -1,0 +1,15 @@
+from .base import Guest
+
+
+class FedoraGuest(Guest):
+    """ This guest can provision Fedora containers. """
+
+    name = 'fedora'
+    barebones_packages = [
+        'openssh-server',
+        'python3',
+    ]
+
+    def install_barebones_packages(self):
+        """ Installs packages when the guest is first provisionned. """
+        self.run(['dnf', '-y', 'install', ] + self.barebones_packages)

--- a/lxdock/guests/gentoo.py
+++ b/lxdock/guests/gentoo.py
@@ -1,0 +1,22 @@
+from .base import Guest
+
+
+class GentooGuest(Guest):
+    """ This guest can provision Gentoo containers. """
+
+    name = 'gentoo'
+    barebones_packages = [
+        'net-misc/openssh',
+        'dev-lang/python',
+    ]
+
+    def install_barebones_packages(self):
+        """ Installs packages when the guest is first provisionned. """
+        # Ensure that we have this Gentoo helper toolkit.
+        # It contains "equery" that can check which package has been installed.
+        self.run(['emerge', 'app-portage/gentoolkit'])
+
+        for p in self.barebones_packages:
+            retcode = self.run(['equery', 'list', p])
+            if retcode != 0:  # Not installed yet
+                self.run(['emerge', p])

--- a/lxdock/guests/opensuse.py
+++ b/lxdock/guests/opensuse.py
@@ -1,0 +1,15 @@
+from .base import Guest
+
+
+class OpenSUSEGuest(Guest):
+    """ This guest can provision openSUSE containers. """
+
+    name = 'opensuse'
+    barebones_packages = [
+        'openSSH',
+        'python3-base',
+    ]
+
+    def install_barebones_packages(self):
+        """ Installs packages when the guest is first provisionned. """
+        self.run(['zypper', '--non-interactive', 'install', ] + self.barebones_packages)

--- a/lxdock/guests/oracle.py
+++ b/lxdock/guests/oracle.py
@@ -1,0 +1,15 @@
+from .base import Guest
+
+
+class OracleLinuxGuest(Guest):
+    """ This guest can provision Oracle Linux containers. """
+
+    name = 'ol'
+    barebones_packages = [
+        'openssh-server',
+        'python',
+    ]
+
+    def install_barebones_packages(self):
+        """ Installs packages when the guest is first provisionned. """
+        self.run(['yum', '-y', 'install'] + self.barebones_packages)

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -80,7 +80,7 @@ class TestContainer(LXDTestCase):
         persistent_container.shell()
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
-            'lxc exec {} -- bash'.format(persistent_container.lxd_name)
+            'lxc exec {} -- su -m root'.format(persistent_container.lxd_name)
 
     @unittest.mock.patch('subprocess.call')
     def test_can_open_a_shell_for_a_specific_shelluser(self, mocked_call):

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -155,4 +155,4 @@ class TestProject(LXDTestCase):
         project.shell(container_name='testcase-persistent')
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
-            'lxc exec {} -- bash'.format(persistent_container.lxd_name)
+            'lxc exec {} -- su -m root'.format(persistent_container.lxd_name)

--- a/tests/unit/guests/test_alpine.py
+++ b/tests/unit/guests/test_alpine.py
@@ -1,0 +1,19 @@
+import unittest.mock
+
+from lxdock.guests import AlpineGuest
+
+
+class TestAlpineGuest:
+    def test_can_install_barebones_packages(self):
+        lxd_container = unittest.mock.Mock()
+        lxd_container.execute.return_value = ('ok', 'ok', '')
+        guest = AlpineGuest(lxd_container)
+        guest.install_barebones_packages()
+        assert lxd_container.execute.call_count == 4
+        assert lxd_container.execute.call_args_list[0][0] == (['apk', 'update'], )
+        assert lxd_container.execute.call_args_list[1][0] == \
+            (['apk', 'add'] + AlpineGuest.barebones_packages, )
+        assert lxd_container.execute.call_args_list[2][0] == \
+            (['rc-update', 'add', 'sshd'], )
+        assert lxd_container.execute.call_args_list[3][0] == \
+            (['/etc/init.d/sshd', 'start'], )

--- a/tests/unit/guests/test_centos.py
+++ b/tests/unit/guests/test_centos.py
@@ -1,0 +1,14 @@
+import unittest.mock
+
+from lxdock.guests import CentosGuest
+
+
+class TestCentosGuest:
+    def test_can_install_barebones_packages(self):
+        lxd_container = unittest.mock.Mock()
+        lxd_container.execute.return_value = ('ok', 'ok', '')
+        guest = CentosGuest(lxd_container)
+        guest.install_barebones_packages()
+        assert lxd_container.execute.call_count == 1
+        assert lxd_container.execute.call_args[0] == \
+            (['yum', '-y', 'install'] + CentosGuest.barebones_packages, )

--- a/tests/unit/guests/test_fedora.py
+++ b/tests/unit/guests/test_fedora.py
@@ -1,0 +1,14 @@
+import unittest.mock
+
+from lxdock.guests import FedoraGuest
+
+
+class TestFedoraGuest:
+    def test_can_install_barebones_packages(self):
+        lxd_container = unittest.mock.Mock()
+        lxd_container.execute.return_value = ('ok', 'ok', '')
+        guest = FedoraGuest(lxd_container)
+        guest.install_barebones_packages()
+        assert lxd_container.execute.call_count == 1
+        assert lxd_container.execute.call_args[0] == \
+            (['dnf', '-y', 'install'] + FedoraGuest.barebones_packages, )

--- a/tests/unit/guests/test_gentoo.py
+++ b/tests/unit/guests/test_gentoo.py
@@ -1,0 +1,30 @@
+import unittest.mock
+
+from lxdock.guests import GentooGuest
+
+
+class TestGentooGuest:
+    def test_should_install_barebones_packages_if_not_installed(self):
+        lxd_container = unittest.mock.Mock()
+        # Retcode 1: "No installed packages matching {keyword}"
+        lxd_container.execute.return_value = (1, 'ok', '')
+        guest = GentooGuest(lxd_container)
+        guest.install_barebones_packages()
+        assert lxd_container.execute.call_count == 1 + 2 * len(GentooGuest.barebones_packages)
+        assert lxd_container.execute.call_args_list[0][0] == \
+            (['emerge', 'app-portage/gentoolkit'], )
+        for i, p in enumerate(GentooGuest.barebones_packages):
+            assert lxd_container.execute.call_args_list[2 * i + 1][0] == (['equery', 'list', p], )
+            assert lxd_container.execute.call_args_list[2 * i + 2][0] == (['emerge', p], )
+
+    def test_should_not_reinstall_barebones_packages_if_already_installed(self):
+        lxd_container = unittest.mock.Mock()
+        # Retcode 0: the package has been found locally
+        lxd_container.execute.return_value = (0, 'ok', '')
+        guest = GentooGuest(lxd_container)
+        guest.install_barebones_packages()
+        assert lxd_container.execute.call_count == 1 + len(GentooGuest.barebones_packages)
+        assert lxd_container.execute.call_args_list[0][0] == \
+            (['emerge', 'app-portage/gentoolkit'], )
+        for i, p in enumerate(GentooGuest.barebones_packages):
+            assert lxd_container.execute.call_args_list[i + 1][0] == (['equery', 'list', p], )

--- a/tests/unit/guests/test_opensuse.py
+++ b/tests/unit/guests/test_opensuse.py
@@ -1,0 +1,15 @@
+import unittest.mock
+
+from lxdock.guests import OpenSUSEGuest
+
+
+class TestOpenSUSEGuest:
+    def test_can_install_barebones_packages(self):
+        lxd_container = unittest.mock.Mock()
+        lxd_container.execute.return_value = ('ok', 'ok', '')
+        guest = OpenSUSEGuest(lxd_container)
+        guest.install_barebones_packages()
+        assert lxd_container.execute.call_count == 1
+        assert lxd_container.execute.call_args[0] == \
+            (['zypper', '--non-interactive', 'install'] +
+             OpenSUSEGuest.barebones_packages, )

--- a/tests/unit/guests/test_oracle.py
+++ b/tests/unit/guests/test_oracle.py
@@ -1,0 +1,14 @@
+import unittest.mock
+
+from lxdock.guests import OracleLinuxGuest
+
+
+class TestOracleLinuxGuest:
+    def test_can_install_barebones_packages(self):
+        lxd_container = unittest.mock.Mock()
+        lxd_container.execute.return_value = ('ok', 'ok', '')
+        guest = OracleLinuxGuest(lxd_container)
+        guest.install_barebones_packages()
+        assert lxd_container.execute.call_count == 1
+        assert lxd_container.execute.call_args[0] == \
+            (['yum', '-y', 'install'] + OracleLinuxGuest.barebones_packages, )


### PR DESCRIPTION
1. Also fixed the regex for detecting Linux distro.
2. Replaced `bash` as `su -m root` in `lxdock shell`, to use the default shell of the Linux distro.