### PR TITLE
New: zsh completion. Closes #25.

### DIFF
--- a/contrib/completion/zsh/_lxdock
+++ b/contrib/completion/zsh/_lxdock
@@ -1,0 +1,126 @@
+#compdef lxdock
+# Zsh completion suppot for LXDock
+#
+# Provides completion for commands, options and container names.
+#
+# Installation instructions:
+#   - place this script at /usr/share/zsh/vendor-completions
+#   - restart your shell
+#
+
+local -a _1st_arguments
+_1st_arguments=(
+  'config:Validate and show the LXDock file'
+  'destroy:Stop and remove containers'
+  'halt:Stop containers'
+  'help:Show help information'
+  'init:Generate a LXDock file'
+  'provision:Provision containers'
+  'shell:Open a shell in a container'
+  "status:Show containers' statuses"
+  'up:Create, start and provision containers'
+)
+
+__subcommand_list ()
+{
+  local expl
+  declare -a subcommands
+
+  subcommands=(config destroy halt init provision shell status up)
+
+  _wanted tasks expl 'help' compadd $subcommands
+}
+
+__container_list ()
+{
+  _lxdock_containers=(
+    $(_call_program path-all "lxdock 2>/dev/null config --containers") )
+
+  if [[ -z "${_lxdock_containers// }" ]]; then
+    _message 'no more arguments: no container defined.'
+  fi
+
+  _wanted application expl 'container' compadd $_lxdock_containers
+}
+
+
+local expl
+local curcontext="$curcontext" state line
+local -A opt_args
+
+_arguments -C \
+           ':command:->command' \
+           '*::arguments:->arguments' \
+
+case $state in
+  (command)
+    _describe -t commands "subcommand" _1st_arguments
+    return
+    ;;
+
+  (arguments)
+    case $line[1] in
+      (config)
+        # lxdock config [-h] [--containers]
+        _arguments '--containers[Display only container names, one per line.]'
+        ;;
+
+      (destroy)
+        # lxdock destroy [-h] [-f] [name [name ...]]
+        _arguments '(-f --force)'{-f,--force}'[Destroy without confirmation]' \
+                   '*::container:__container_list' \
+        ;;
+
+      (halt)
+        # lxdock halt [-h] [name [name ...]]
+        _arguments '*::container:__container_list' \
+        ;;
+
+      (help)
+        # lxdock help [-h] [subcommand]
+        _arguments ':subcommand:__subcommand_list'
+        ;;
+
+      (init)
+        # lxdock init [-h] [-f] [--image IMAGE] [--project PROJECT]
+        _arguments '(-f --force)'{-f,--force}'[Overwrite existing LXDock file]' \
+                   '--image[Container image to use]:image:' \
+                   '--project[Project name to use]:project:'
+        ;;
+
+      (provision)
+        # lxdock provision [-h] [name [name ...]]
+        _arguments '*::container:__container_list' \
+        ;;
+
+      (shell)
+        # lxdock shell [-h] [-u USERNAME] [name]
+        _arguments '(-u --username)'{-u,--username}'[Username to login as]:username:' \
+                   '::container:__container_list' \
+
+        ;;
+
+      (status)
+        # lxdock status [-h] [name [name ...]]
+        _arguments '*::container:__container_list' \
+        ;;
+
+      (up)
+        # lxdock up [-h] [name [name ...]]
+        _arguments '*::container:__container_list' \
+        ;;
+
+      *)
+        (( ret )) && _message 'no arguments'
+        ;;
+    esac
+    ;;
+esac
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -87,7 +87,7 @@ You should now be able to install LXDock using:
 Command line completion
 -----------------------
 
-LXDock can provide completion for commands and container names.
+LXDock can provide completion for commands, options and container names.
 
 Bash
 ~~~~
@@ -106,7 +106,14 @@ Make sure to restart your shell before trying to use LXDock's bash completion.
 ZSH
 ~~~
 
-*Not yet!* But feel free to contribute (please refer to :doc:`contributing`)!
+To add zsh completion for LXDock, place the ``contrib/completion/zsh/_lxdock`` file at
+``/usr/share/zsh/vendor-completions/_lxdock`` (or another folder in ``$fpath``):
+
+.. code-block:: console
+
+  $ sudo cp contrib/completion/zsh/_lxdock /usr/share/zsh/vendor-completions/_lxdock
+
+Make sure to restart your shell before trying to use LXDock's zsh completion.
 
 Your first LXDock file
 ----------------------


### PR DESCRIPTION
Ref issue #25.

Commands for completion (according to lxdock help messages, and `-h` options are not included):
- lxdock config [-h] [--containers]
- lxdock destroy [-h] [-f] [name [name ...]]
- lxdock halt [-h] [name [name ...]]
- lxdock help [-h] [subcommand]
- lxdock init [-h] [-f] [--image IMAGE] [--project PROJECT]
- lxdock provision [-h] [name [name ...]]
- lxdock shell [-h] [-u USERNAME] [name]
- lxdock status [-h] [name [name ...]]
- lxdock up [-h] [name [name ...]]


How to test:
1. Install zsh and follow the updated doc to configure the completion.
2. Restart zsh.
3. Create a test folder and an example `lxdock.yml` in it, or go to an existing folder that contains file `lxdock.yml`. (It could also be: .lxdock.yml, .lxdock.yaml, lxdock.yml, lxdock.yaml, .nomad.yml, .nomad.yaml, nomad.yml, nomad.yaml)
4. Test completion of 1st argument:
    4.1 Type `lxdock` then press TAB a few times.
    4.2 Verify commands and descriptions.
5. Test completion of `lxdock help`:
    5.1 Type `lxdock help` then press TAB a few times.
    5.2 Verify the completions.
6. Test if completion works as expected with other commands. Several notes:
    6.1 The options should always be prior to container names, i.e., after typing `lxdock COMMAND `, putting a dash then TAB will ask for an option (if there are options), but once we have a container name, e.g. when we have typed `lxdock COMMAND container-name-1`, a new dash will only be completed as a container name (e.g., zsh may complete a dash to `"container-name-2"` because there are dashes in this string).
    6.2 If an option requires an argument (e.g., --image), after completing this option, zsh should ask for providing the argument.
    6.3 For `lxdock shell`, there should be at most one container name, so zsh should not ask for more container names.
7. Test updating `lxdock.yml`
    7.1 Use any command to trigger zsh completion.
    7.2 Modify a container's name in `lxdock.yml` and save.
    7.3 Trigger zsh completion again. You should see the change in the completion.
8. Test without `lxdock.yml`
    8.1 Create a new folder and `cd` there.
    8.2 Use any command that can trigger zsh completion on **container names**.
    8.3 Press TAB, you should be prompted "no more arguments: no container defined.".
