### PR TITLE
Accept custom LXC configuration

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -122,6 +122,25 @@ And then use it in your LXDock file as follows:
   image: old-ubuntu
   mode: local
 
+lxc_config
+-----------
+
+If your container needs custom configuration settings, you can use ``lxc_config`` to pass any arbitrary
+key-value pairs that you want to be assigned to the container at startup. ``lxc_config`` must be a dictionary 
+that with an arbitrary number of key-values.
+
+.. code-block:: yaml
+
+  name: myproject
+  image: ubuntu/xenial
+  lxc_config:
+    global_key: global_value
+
+  containers:
+    - name: test01
+      test1_key: test1_value
+    - name: test02
+
 mode
 ----
 

--- a/lxdock/conf/config.py
+++ b/lxdock/conf/config.py
@@ -111,6 +111,14 @@ class Config(object):
         and can be used by each container.
         """
         container_config = dict(self._dict)
+
+        # If both global and container scope contains lxc_config, merge them
+        lxck = 'lxc_config'
+        if lxck in container_config and lxck in container_dict:
+            container_dict = dict(container_dict)
+            container_config[lxck].update(container_dict[lxck])
+            del container_dict[lxck]
+
         container_config.update(container_dict)
         del container_config['containers']
         return container_config

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -9,6 +9,7 @@ _top_level_and_containers_common_options = {
     'environment': {Extra: Coerce(str)},
     'hostnames': [Hostname(), ],
     'image': str,
+    'lxc_config': {Extra: str},
     'mode': In(['local', 'pull', ]),
     'privileged': bool,
     'protocol': In(['lxd', 'simplestreams', ]),

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -259,6 +259,17 @@ class Container:
             'from image {image}'.format(name=self.lxd_name, image=self.options['image']))
         privileged = self.options.get('privileged', False)
         mode = self.options.get('mode', 'pull')
+
+        # Get user defined lxc configs
+        lxc_config = self.options.get('lxc_config', {}).copy()
+
+        # Overwrite any configuration settings with lxdock defaults
+        lxc_config.update({
+            'security.privileged': 'true' if privileged else 'false',
+            'user.lxdock.made': '1',
+            'user.lxdock.homedir': self.homedir,
+        })
+
         container_config = {
             'name': self.lxd_name,
             'source': {
@@ -280,12 +291,9 @@ class Container:
                            else ''),
                 'type': 'image',
             },
-            'config': {
-                'security.privileged': 'true' if privileged else 'false',
-                'user.lxdock.made': '1',
-                'user.lxdock.homedir': self.homedir,
-            },
+            'config': lxc_config,
         }
+
         try:
             return self.client.containers.create(container_config, wait=True)
         except LXDAPIException as e:

--- a/tests/unit/conf/fixtures/lxc_config/lxdock.yml
+++ b/tests/unit/conf/fixtures/lxc_config/lxdock.yml
@@ -1,0 +1,9 @@
+name: project
+image: image
+lxc_config:
+  global_key: global_value
+
+containers:
+  - name: lxdock-test-lxc-config
+    lxc_config:
+      cont1_key: cont1_value

--- a/tests/unit/conf/test_config.py
+++ b/tests/unit/conf/test_config.py
@@ -73,3 +73,9 @@ class TestConfig:
         project_dir = os.path.join(FIXTURE_ROOT, 'project01')
         config = Config.from_base_dir(project_dir)
         assert config.serialize() == 'image: ubuntu/xenial\nmode: pull\nname: project01\n'
+
+    def test_can_read_lxc_config(self):
+        project_dir = os.path.join(FIXTURE_ROOT, 'lxc_config')
+        config = Config.from_base_dir(project_dir)
+        assert config.containers[0]['lxc_config'] == {'global_key': 'global_value',
+                                                      'cont1_key': 'cont1_value'}


### PR DESCRIPTION
Provide a way to pass custom LXC parameters for a container, as an advanced setting.

The need for this arose from this bug:

https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/1575779

The only way I have to found to work around is to set the container to `raw.lxc: lxc.aa_profile=unconfined`.

