### PR TITLE
A solution for denied permissions

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -58,6 +58,14 @@ You should now be able to configure your LXD installation using:
     $ sudo lxd init --auto
     $ lxc network create lxdbr0 ipv6.address=none ipv4.address=10.0.3.1/24 ipv4.nat=true
     $ lxc network attach-profile lxdbr0 default eth0
+ 
+ If you received a permission denied error running the lxc network commands, run these 
+ commands below and then run the lxc network commands again.
+ 
+ .. code-block:: console
+ 
+    $ sudo systemctl stop lxd.socket
+    $ sudo systemctl start lxd.socket
 
 You can now check if your LXD installation is working using:
 


### PR DESCRIPTION
When installing lxd and configuring the network as outlined in the getting started guide, permissions are not set correctly to execute the lxc network commands properly. By restarting lxd.socket, permissions are verified and configuration continues with no problem. The user receives this output when running the lxc network commands "Permission denied, are you in the lxd group?".

Many people are experiencing this error when installing and setting up lxd. Here is a google search link as an example of how this problem is affecting others [google search link](https://www.google.com/search?q=Permission+denied%2C+are+you+in+the+lxd+group%3F&oq=Permission+denied%2C+are+you+in+the+lxd+group%3F&aqs=chrome..69i57.332j0j1&sourceid=chrome&ie=UTF-8). Here is a link to one example of users having this issue and where I came across the solution I provided in this pull request [link](https://github.com/lxc/lxd/issues/1635). The other solution I came across was to have the user to restart their user session.

I appreciate the work the organizers have put in this project and would like to say thank you to all of the contributors. This project is very cool and LXDock was a solution I was looking for in managing my linux containers.

-------
Installation Following the Guide Tested on the Following System:

Installed LXD with the provided ppa in the docks on Ubuntu 16.04 LTS 64 bit.