### PR TITLE
shell: add a way to set environment variables

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -211,8 +211,12 @@ of shared items. Each shared item should define a ``source`` (a path on your hos
 shell
 -----
 
-The ``shell`` option allows you to define the user to use when doing a ``lxdock shell``. This allows
-you to have a shell for a specific user/home directory when doing ``lxdock shell``:
+The ``shell`` option alters the behavior of the ``lxdock shell`` command. It's a map of these
+sub-options:
+
+* ``user``: Default user to open the shell under.
+* ``home``: Path to open the shell under.
+* ``environment``: A mapping of environment variables to set in the shell.
 
 .. code-block:: yaml
 
@@ -222,6 +226,8 @@ you to have a shell for a specific user/home directory when doing ``lxdock shell
   shell:
     user: myuser
     home: /opt/myproject
+    environment:
+      LC_ALL: en_US.utf8
 
 users
 -----

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -47,6 +47,20 @@ containers, as follows:
     - name: test01
     - name: test02
 
+environment
+-----------
+
+A mapping of environment variables to override in the container when executing commands. This will
+affect ``lxdock shell`` and ``lxdock provision`` operations.
+
+.. code-block:: yaml
+
+  name: myproject
+  image: ubuntu/xenial
+
+  environment:
+    LC_ALL: en_US.utf8
+
 hostnames
 ---------
 
@@ -216,7 +230,6 @@ sub-options:
 
 * ``user``: Default user to open the shell under.
 * ``home``: Path to open the shell under.
-* ``environment``: A mapping of environment variables to set in the shell.
 
 .. code-block:: yaml
 
@@ -226,8 +239,6 @@ sub-options:
   shell:
     user: myuser
     home: /opt/myproject
-    environment:
-      LC_ALL: en_US.utf8
 
 users
 -----

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -1,4 +1,4 @@
-from voluptuous import All, Any, In, IsDir, Length, Required, Schema, Url
+from voluptuous import All, Any, Extra, In, IsDir, Length, Required, Schema, Url
 
 from ..provisioners import Provisioner
 
@@ -21,6 +21,7 @@ _top_level_and_containers_common_options = {
     'shell': {
         'user': str,
         'home': str,
+        'environment': {Extra: str},
     },
     'users': [{
         # Usernames max length is set 32 characters according to useradd's man page.

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -6,6 +6,7 @@ from .validators import Hostname, LXDIdentifier
 
 
 _top_level_and_containers_common_options = {
+    'environment': {Extra: Coerce(str)},
     'hostnames': [Hostname(), ],
     'image': str,
     'mode': In(['local', 'pull', ]),
@@ -21,7 +22,6 @@ _top_level_and_containers_common_options = {
     'shell': {
         'user': str,
         'home': str,
-        'environment': {Extra: Coerce(str)},
     },
     'users': [{
         # Usernames max length is set 32 characters according to useradd's man page.

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -1,4 +1,4 @@
-from voluptuous import All, Any, Extra, In, IsDir, Length, Required, Schema, Url
+from voluptuous import All, Any, Coerce, Extra, In, IsDir, Length, Required, Schema, Url
 
 from ..provisioners import Provisioner
 
@@ -21,7 +21,7 @@ _top_level_and_containers_common_options = {
     'shell': {
         'user': str,
         'home': str,
-        'environment': {Extra: str},
+        'environment': {Extra: Coerce(str)},
     },
     'users': [{
         # Usernames max length is set 32 characters according to useradd's man page.

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -103,6 +103,11 @@ class Container:
         # to pylxd so it supports `interactive = True` in `exec()`.
         shellcfg = self.options.get('shell', {})
         shelluser = username or shellcfg.get('user')
+        shellenv = shellcfg.get('environment')
+        if shellenv:
+            for key, value in shellenv.items():
+                self._container.config['environment.{}'.format(key)] = value
+            self._container.save(wait=True)
         if shelluser:
             # This part is the result of quite a bit of `su` args trial-and-error.
             shellhome = shellcfg.get('home') if not username else None

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -106,7 +106,7 @@ class Container:
         shellenv = shellcfg.get('environment')
         if shellenv:
             for key, value in shellenv.items():
-                self._container.config['environment.{}'.format(key)] = value
+                self._container.config['environment.{}'.format(key)] = str(value)
             self._container.save(wait=True)
         if shelluser:
             # This part is the result of quite a bit of `su` args trial-and-error.

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -95,6 +95,18 @@ class TestContainer(LXDTestCase):
         assert mocked_call.call_args[0][0] == \
             'lxc exec {} --env HOME=/opt -- su -m test'.format(container.lxd_name)
 
+    @unittest.mock.patch('subprocess.call')
+    def test_can_set_shell_environment_variables(self, mocked_call):
+        # Environment variables in the shell can be set through configuration.
+        container_options = {
+            'name': self.containername('dummy'), 'image': 'ubuntu/xenial', 'mode': 'pull',
+            'shell': {'environment': {'FOO': 'bar'}},
+        }
+        container = Container('myproject', THIS_DIR, self.client, **container_options)
+        container.up()
+        container.shell()
+        assert container._container.config['environment.FOO'] == 'bar'
+
     def test_can_tell_if_a_container_exists_or_not(self, persistent_container):
         unkonwn_container = Container('myproject', THIS_DIR, self.client, **{
             'name': self.containername('unkonwn'), 'image': 'ubuntu/xenial', 'mode': 'pull', })

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -100,7 +100,7 @@ class TestContainer(LXDTestCase):
         # Environment variables in the shell can be set through configuration.
         container_options = {
             'name': self.containername('shell-env'), 'image': 'ubuntu/xenial',
-            'shell': {'environment': {'FOO': 'bar', 'BAR': 42}},
+            'environment': {'FOO': 'bar', 'BAR': 42},
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.up()

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -100,12 +100,13 @@ class TestContainer(LXDTestCase):
         # Environment variables in the shell can be set through configuration.
         container_options = {
             'name': self.containername('shell-env'), 'image': 'ubuntu/xenial',
-            'shell': {'environment': {'FOO': 'bar'}},
+            'shell': {'environment': {'FOO': 'bar', 'BAR': 42}},
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.up()
         container.shell()
         assert container._container.config['environment.FOO'] == 'bar'
+        assert container._container.config['environment.BAR'] == '42'
 
     def test_can_tell_if_a_container_exists_or_not(self, persistent_container):
         unkonwn_container = Container('myproject', THIS_DIR, self.client, **{

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -99,7 +99,7 @@ class TestContainer(LXDTestCase):
     def test_can_set_shell_environment_variables(self, mocked_call):
         # Environment variables in the shell can be set through configuration.
         container_options = {
-            'name': self.containername('dummy'), 'image': 'ubuntu/xenial', 'mode': 'pull',
+            'name': self.containername('shell-env'), 'image': 'ubuntu/xenial',
             'shell': {'environment': {'FOO': 'bar'}},
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)


### PR DESCRIPTION
Add a new config dictionary in the `shell` key: `environment`. All
values in this dictionary are passed to LXD's config under the
"environment.*" config type.

We set this config when `shell` is called, which is a bit at odds with
the rest of the container config, which is usually set at creation time.
We do this so that a user who fiddles with her `lxdock.yml` file doesn't
have to restart/recreate her container to benefit from the change she's
just made. They will be effective on the next `lxdock shell` call.
