### PR TITLE
Improve user's home directory assignment

### DIFF
--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -105,7 +105,11 @@ class Container:
         shelluser = username or shellcfg.get('user')
         if shelluser:
             # This part is the result of quite a bit of `su` args trial-and-error.
-            shellhome = shellcfg.get('home') if not username else None
+            shellhome = None
+            if not username:
+                shellhome = shellcfg.get('home')
+                if not shellhome and shelluser != 'root':
+                    shellhome = os.path.join(os.sep, 'home', shelluser)
             homearg = '--env HOME={}'.format(shellhome) if shellhome else ''
             cmd = 'lxc exec {} {} -- su -m {}'.format(self.lxd_name, homearg, shelluser)
             subprocess.call(cmd, shell=True)

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -105,11 +105,9 @@ class Container:
         shelluser = username or shellcfg.get('user')
         if shelluser:
             # This part is the result of quite a bit of `su` args trial-and-error.
-            shellhome = None
-            if not username:
-                shellhome = shellcfg.get('home')
-                if not shellhome and shelluser != 'root':
-                    shellhome = os.path.join(os.sep, 'home', shelluser)
+            shellhome = shellcfg.get('home')
+            if not shellhome and shelluser != 'root':
+                shellhome = os.path.join(os.sep, 'home', shelluser)
             homearg = '--env HOME={}'.format(shellhome) if shellhome else ''
             cmd = 'lxc exec {} {} -- su -m {}'.format(self.lxd_name, homearg, shelluser)
             subprocess.call(cmd, shell=True)


### PR DESCRIPTION
If a shell user defined without a home directory setting, assign home directory to /home/user (unless root).