### PR TITLE
Make "barebone" packages be installed for ansible only

### DIFF
--- a/lxdock/guests/alpine.py
+++ b/lxdock/guests/alpine.py
@@ -5,14 +5,13 @@ class AlpineGuest(Guest):
     """ This guest can provision Alpine containers. """
 
     name = 'alpine'
-    barebones_packages = [
+    ansible_packages = [
         'openssh',
         'python',
     ]
 
-    def install_barebones_packages(self):
-        """ Installs packages when the guest is first provisionned. """
+    def install_ansible_packages(self):
         self.run(['apk', 'update'])
-        self.run(['apk', 'add'] + self.barebones_packages)
+        self.run(['apk', 'add'] + self.ansible_packages)
         self.run(['rc-update', 'add', 'sshd'])
         self.run(['/etc/init.d/sshd', 'start'])

--- a/lxdock/guests/archlinux.py
+++ b/lxdock/guests/archlinux.py
@@ -5,11 +5,10 @@ class ArchLinuxGuest(Guest):
     """ This guest can provision ArchLinux containers. """
 
     name = 'arch'
-    barebones_packages = [
+    ansible_packages = [
         'openssh',
         'python2',
     ]
 
-    def install_barebones_packages(self):
-        """ Installs packages when the guest is first provisionned. """
-        self.run(['pacman', '-S', '--noconfirm'] + self.barebones_packages)
+    def install_ansible_packages(self):
+        self.run(['pacman', '-S', '--noconfirm'] + self.ansible_packages)

--- a/lxdock/guests/base.py
+++ b/lxdock/guests/base.py
@@ -120,8 +120,8 @@ class Guest(with_metaclass(_GuestBase)):
     # METHODS THAT SHOULD BE OVERRIDEN IN GUEST SUBCLASSES #
     ########################################################
 
-    def install_barebones_packages(self):  # pragma: no cover
-        """ Installs packages when the guest is first provisionned. """
+    def install_ansible_packages(self):  # pragma: no cover
+        """ Installs packages needed to run ansible on the guest. """
         # This method should be overriden in `Guest` subclasses.
         self._warn_guest_not_supported('for installing bare bones packages')
 

--- a/lxdock/guests/centos.py
+++ b/lxdock/guests/centos.py
@@ -5,11 +5,10 @@ class CentosGuest(Guest):
     """ This guest can provision Centos containers. """
 
     name = 'centos'
-    barebones_packages = [
+    ansible_packages = [
         'openssh-server',
         'python',
     ]
 
-    def install_barebones_packages(self):
-        """ Installs packages when the guest is first provisionned. """
-        self.run(['yum', '-y', 'install'] + self.barebones_packages)
+    def install_ansible_packages(self):
+        self.run(['yum', '-y', 'install'] + self.ansible_packages)

--- a/lxdock/guests/debian.py
+++ b/lxdock/guests/debian.py
@@ -5,13 +5,12 @@ class DebianGuest(Guest):
     """ This guest can provision Debian containers. """
 
     name = 'debian'
-    barebones_packages = [
+    ansible_packages = [
         'apt-utils',
         'aptitude',
         'openssh-server',
         'python',
     ]
 
-    def install_barebones_packages(self):
-        """ Installs packages when the guest is first provisionned. """
-        self.run(['apt-get', 'install', '-y'] + self.barebones_packages)
+    def install_ansible_packages(self):
+        self.run(['apt-get', 'install', '-y'] + self.ansible_packages)

--- a/lxdock/guests/fedora.py
+++ b/lxdock/guests/fedora.py
@@ -5,11 +5,10 @@ class FedoraGuest(Guest):
     """ This guest can provision Fedora containers. """
 
     name = 'fedora'
-    barebones_packages = [
+    ansible_packages = [
         'openssh-server',
         'python3',
     ]
 
-    def install_barebones_packages(self):
-        """ Installs packages when the guest is first provisionned. """
-        self.run(['dnf', '-y', 'install', ] + self.barebones_packages)
+    def install_ansible_packages(self):
+        self.run(['dnf', '-y', 'install', ] + self.ansible_packages)

--- a/lxdock/guests/gentoo.py
+++ b/lxdock/guests/gentoo.py
@@ -5,18 +5,17 @@ class GentooGuest(Guest):
     """ This guest can provision Gentoo containers. """
 
     name = 'gentoo'
-    barebones_packages = [
+    ansible_packages = [
         'net-misc/openssh',
         'dev-lang/python',
     ]
 
-    def install_barebones_packages(self):
-        """ Installs packages when the guest is first provisionned. """
+    def install_ansible_packages(self):
         # Ensure that we have this Gentoo helper toolkit.
         # It contains "equery" that can check which package has been installed.
         self.run(['emerge', 'app-portage/gentoolkit'])
 
-        for p in self.barebones_packages:
+        for p in self.ansible_packages:
             retcode = self.run(['equery', 'list', p])
             if retcode != 0:  # Not installed yet
                 self.run(['emerge', p])

--- a/lxdock/guests/opensuse.py
+++ b/lxdock/guests/opensuse.py
@@ -5,11 +5,10 @@ class OpenSUSEGuest(Guest):
     """ This guest can provision openSUSE containers. """
 
     name = 'opensuse'
-    barebones_packages = [
+    ansible_packages = [
         'openSSH',
         'python3-base',
     ]
 
-    def install_barebones_packages(self):
-        """ Installs packages when the guest is first provisionned. """
-        self.run(['zypper', '--non-interactive', 'install', ] + self.barebones_packages)
+    def install_ansible_packages(self):
+        self.run(['zypper', '--non-interactive', 'install', ] + self.ansible_packages)

--- a/lxdock/guests/oracle.py
+++ b/lxdock/guests/oracle.py
@@ -5,11 +5,10 @@ class OracleLinuxGuest(Guest):
     """ This guest can provision Oracle Linux containers. """
 
     name = 'ol'
-    barebones_packages = [
+    ansible_packages = [
         'openssh-server',
         'python',
     ]
 
-    def install_barebones_packages(self):
-        """ Installs packages when the guest is first provisionned. """
-        self.run(['yum', '-y', 'install'] + self.barebones_packages)
+    def install_ansible_packages(self):
+        self.run(['yum', '-y', 'install'] + self.ansible_packages)

--- a/tests/unit/guests/test_alpine.py
+++ b/tests/unit/guests/test_alpine.py
@@ -8,11 +8,11 @@ class TestAlpineGuest:
         lxd_container = unittest.mock.Mock()
         lxd_container.execute.return_value = ('ok', 'ok', '')
         guest = AlpineGuest(lxd_container)
-        guest.install_barebones_packages()
+        guest.install_ansible_packages()
         assert lxd_container.execute.call_count == 4
         assert lxd_container.execute.call_args_list[0][0] == (['apk', 'update'], )
         assert lxd_container.execute.call_args_list[1][0] == \
-            (['apk', 'add'] + AlpineGuest.barebones_packages, )
+            (['apk', 'add'] + AlpineGuest.ansible_packages, )
         assert lxd_container.execute.call_args_list[2][0] == \
             (['rc-update', 'add', 'sshd'], )
         assert lxd_container.execute.call_args_list[3][0] == \

--- a/tests/unit/guests/test_archlinux.py
+++ b/tests/unit/guests/test_archlinux.py
@@ -8,7 +8,7 @@ class TestArchLinuxGuest:
         lxd_container = unittest.mock.Mock()
         lxd_container.execute.return_value = ('ok', 'ok', '')
         guest = ArchLinuxGuest(lxd_container)
-        guest.install_barebones_packages()
+        guest.install_ansible_packages()
         assert lxd_container.execute.call_count == 1
         assert lxd_container.execute.call_args[0] == \
-            (['pacman', '-S', '--noconfirm'] + ArchLinuxGuest.barebones_packages, )
+            (['pacman', '-S', '--noconfirm'] + ArchLinuxGuest.ansible_packages, )

--- a/tests/unit/guests/test_centos.py
+++ b/tests/unit/guests/test_centos.py
@@ -8,7 +8,7 @@ class TestCentosGuest:
         lxd_container = unittest.mock.Mock()
         lxd_container.execute.return_value = ('ok', 'ok', '')
         guest = CentosGuest(lxd_container)
-        guest.install_barebones_packages()
+        guest.install_ansible_packages()
         assert lxd_container.execute.call_count == 1
         assert lxd_container.execute.call_args[0] == \
-            (['yum', '-y', 'install'] + CentosGuest.barebones_packages, )
+            (['yum', '-y', 'install'] + CentosGuest.ansible_packages, )

--- a/tests/unit/guests/test_debian.py
+++ b/tests/unit/guests/test_debian.py
@@ -8,7 +8,7 @@ class TestDebianGuest:
         lxd_container = unittest.mock.Mock()
         lxd_container.execute.return_value = ('ok', 'ok', '')
         guest = DebianGuest(lxd_container)
-        guest.install_barebones_packages()
+        guest.install_ansible_packages()
         assert lxd_container.execute.call_count == 1
         assert lxd_container.execute.call_args[0] == \
-            (['apt-get', 'install', '-y'] + DebianGuest.barebones_packages, )
+            (['apt-get', 'install', '-y'] + DebianGuest.ansible_packages, )

--- a/tests/unit/guests/test_fedora.py
+++ b/tests/unit/guests/test_fedora.py
@@ -8,7 +8,7 @@ class TestFedoraGuest:
         lxd_container = unittest.mock.Mock()
         lxd_container.execute.return_value = ('ok', 'ok', '')
         guest = FedoraGuest(lxd_container)
-        guest.install_barebones_packages()
+        guest.install_ansible_packages()
         assert lxd_container.execute.call_count == 1
         assert lxd_container.execute.call_args[0] == \
-            (['dnf', '-y', 'install'] + FedoraGuest.barebones_packages, )
+            (['dnf', '-y', 'install'] + FedoraGuest.ansible_packages, )

--- a/tests/unit/guests/test_gentoo.py
+++ b/tests/unit/guests/test_gentoo.py
@@ -9,11 +9,11 @@ class TestGentooGuest:
         # Retcode 1: "No installed packages matching {keyword}"
         lxd_container.execute.return_value = (1, 'ok', '')
         guest = GentooGuest(lxd_container)
-        guest.install_barebones_packages()
-        assert lxd_container.execute.call_count == 1 + 2 * len(GentooGuest.barebones_packages)
+        guest.install_ansible_packages()
+        assert lxd_container.execute.call_count == 1 + 2 * len(GentooGuest.ansible_packages)
         assert lxd_container.execute.call_args_list[0][0] == \
             (['emerge', 'app-portage/gentoolkit'], )
-        for i, p in enumerate(GentooGuest.barebones_packages):
+        for i, p in enumerate(GentooGuest.ansible_packages):
             assert lxd_container.execute.call_args_list[2 * i + 1][0] == (['equery', 'list', p], )
             assert lxd_container.execute.call_args_list[2 * i + 2][0] == (['emerge', p], )
 
@@ -22,9 +22,9 @@ class TestGentooGuest:
         # Retcode 0: the package has been found locally
         lxd_container.execute.return_value = (0, 'ok', '')
         guest = GentooGuest(lxd_container)
-        guest.install_barebones_packages()
-        assert lxd_container.execute.call_count == 1 + len(GentooGuest.barebones_packages)
+        guest.install_ansible_packages()
+        assert lxd_container.execute.call_count == 1 + len(GentooGuest.ansible_packages)
         assert lxd_container.execute.call_args_list[0][0] == \
             (['emerge', 'app-portage/gentoolkit'], )
-        for i, p in enumerate(GentooGuest.barebones_packages):
+        for i, p in enumerate(GentooGuest.ansible_packages):
             assert lxd_container.execute.call_args_list[i + 1][0] == (['equery', 'list', p], )

--- a/tests/unit/guests/test_opensuse.py
+++ b/tests/unit/guests/test_opensuse.py
@@ -8,8 +8,8 @@ class TestOpenSUSEGuest:
         lxd_container = unittest.mock.Mock()
         lxd_container.execute.return_value = ('ok', 'ok', '')
         guest = OpenSUSEGuest(lxd_container)
-        guest.install_barebones_packages()
+        guest.install_ansible_packages()
         assert lxd_container.execute.call_count == 1
         assert lxd_container.execute.call_args[0] == \
             (['zypper', '--non-interactive', 'install'] +
-             OpenSUSEGuest.barebones_packages, )
+             OpenSUSEGuest.ansible_packages, )

--- a/tests/unit/guests/test_oracle.py
+++ b/tests/unit/guests/test_oracle.py
@@ -8,7 +8,7 @@ class TestOracleLinuxGuest:
         lxd_container = unittest.mock.Mock()
         lxd_container.execute.return_value = ('ok', 'ok', '')
         guest = OracleLinuxGuest(lxd_container)
-        guest.install_barebones_packages()
+        guest.install_ansible_packages()
         assert lxd_container.execute.call_count == 1
         assert lxd_container.execute.call_args[0] == \
-            (['yum', '-y', 'install'] + OracleLinuxGuest.barebones_packages, )
+            (['yum', '-y', 'install'] + OracleLinuxGuest.ansible_packages, )


### PR DESCRIPTION
Those packages were always a misnomer. They're not really "barebone",
they're required only for ansible to be able to run properly. With new
provisioners coming in soon, it becomes inefficient to install those
packages on *every* container, even those not running ansible.

Moreover, it has an immediate side effect: it makes some integration
tests run much faster.