### PR TITLE
tests: remove spurious class-level teardown

### DIFF
--- a/lxdock/test/testcases.py
+++ b/lxdock/test/testcases.py
@@ -26,10 +26,6 @@ def _remove_test_containers(client=None):
 class LXDTestCase:
     """ Base test class used to run integration tests that require the use of LXD. """
 
-    @classmethod
-    def teardown_class(cls):
-        _remove_test_containers()
-
     def teardown_method(self, method):
         _remove_test_containers(client=self.client)
 


### PR DESCRIPTION
We've been having multiple cases of flaky tests failures from Travis
lately and they always come from the class-level teardown. Because I
can't figure why we even have it here (in case we ever, hum, create some
test containers *after* the last test method has run?) and because
removing it didn't result in tests leaking out test containers on my
machine, I therefore propose to remove it and make our tests stop being
flaky.