### PR TITLE
Add support for custom user passwords

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -229,7 +229,10 @@ users
 The ``users`` option allows you to define users that should be created by LXDock after creating a
 container. This can be useful because the users created this way will automatically have read/write
 permissions on shared folders. The ``users`` option should contain a list of users; each with a
-``name`` and optionally a custom ``home`` directory:
+``name`` and optionally a custom ``home`` directory or custom ``password``.
+
+Passwords are encrypted using crypt(3) as explained in the useradd manpage, see ``man useradd``
+for more information:
 
 .. code-block:: yaml
 
@@ -240,3 +243,5 @@ permissions on shared folders. The ``users`` option should contain a list of use
     - name: test01
     - name: test02
       home: /opt/test02
+    - name: test03
+      password: $6$cGzZBkDjOhGW$6C9wwqQteFEY4lQ6ZJBggE568SLSS7bIMKexwOD39mJQrJcZ5vIKJVIfwsKOZajhbPw0.Zqd0jU2NDLAnp9J/1

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -26,6 +26,7 @@ _top_level_and_containers_common_options = {
         # Usernames max length is set 32 characters according to useradd's man page.
         Required('name'): All(str, Length(max=32)),
         'home': str,
+        'password': str,
     }],
 }
 

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -363,7 +363,8 @@ class Container:
         for user_config in users:
             name = user_config.get('name')
             home = user_config.get('home')
-            self._guest.create_user(name, home=home)
+            password = user_config.get('password')
+            self._guest.create_user(name, home=home, password=password)
 
     def _unsetup_hostnames(self):
         """ Removes the configuration associated with the hostnames of the container. """

--- a/lxdock/guests/base.py
+++ b/lxdock/guests/base.py
@@ -109,12 +109,14 @@ class Guest(with_metaclass(_GuestBase)):
         self.run(['mkdir', '-p', '/root/.ssh'])
         self.lxd_container.files.put('/root/.ssh/authorized_keys', pubkey)
 
-    def create_user(self, username, home=None):
+    def create_user(self, username, home=None, password=None):
         """ Adds the passed user to the container system. """
-        home_options = ['--create-home', ]
+        options = ['--create-home', ]
         if home is not None:
-            home_options += ['--home-dir', home, ]
-        self.run(['useradd', ] + home_options + [username, ])
+            options += ['--home-dir', home, ]
+        if password is not None:
+            options += ['-p', password, ]
+        self.run(['useradd', ] + options + [username, ])
 
     ########################################################
     # METHODS THAT SHOULD BE OVERRIDEN IN GUEST SUBCLASSES #

--- a/tests/unit/guests/test_base.py
+++ b/tests/unit/guests/test_base.py
@@ -54,7 +54,20 @@ class TestGuest:
         lxd_container = unittest.mock.Mock()
         lxd_container.execute.return_value = ('ok', 'ok', '')
         guest = DummyGuest(lxd_container)
-        guest.create_user('usertest', '/opt/usertest')
+        guest.create_user('usertest', home='/opt/usertest')
         assert lxd_container.execute.call_count == 1
         assert lxd_container.execute.call_args[0] == \
             (['useradd', '--create-home', '--home-dir', '/opt/usertest', 'usertest'], )
+
+    def test_can_create_a_user_with_a_custom_password(self):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        lxd_container = unittest.mock.Mock()
+        lxd_container.execute.return_value = ('ok', 'ok', '')
+        password = '$6$cGzZBkDjOhGW$6C9wwqQteFEY4lQ6ZJBggE568SLSS7bIMKexwOD' \
+                   '39mJQrJcZ5vIKJVIfwsKOZajhbPw0.Zqd0jU2NDLAnp9J/1'
+        guest = DummyGuest(lxd_container)
+        guest.create_user('usertest', password=password)
+        assert lxd_container.execute.call_count == 1
+        assert lxd_container.execute.call_args[0] == \
+            (['useradd', '-p', password, 'usertest'], )

--- a/tests/unit/guests/test_base.py
+++ b/tests/unit/guests/test_base.py
@@ -70,4 +70,4 @@ class TestGuest:
         guest.create_user('usertest', password=password)
         assert lxd_container.execute.call_count == 1
         assert lxd_container.execute.call_args[0] == \
-            (['useradd', '-p', password, 'usertest'], )
+            (['useradd', '--create-home', '-p', password, 'usertest'], )


### PR DESCRIPTION
Adds support for user passwords, passwords must be encrypted using crypt, for example:

mkpasswd --method=sha-512 'password'

Includes tests and documentation update.