### PR TITLE
Fixed #61: add support for passing `-c command_line` to lxdock shell

### DIFF
--- a/contrib/completion/bash/lxdock
+++ b/contrib/completion/bash/lxdock
@@ -69,7 +69,7 @@ _lxdock_complete () {
         shell)
           case "${cur}" in
             -*)
-              COMPREPLY=($(compgen -W "-u --username" -- ${cur})) ;;
+              COMPREPLY=($(compgen -W "-u --username -c --command" -- ${cur})) ;;
             *)
               containers="$(___lxdock_container_names)"
               COMPREPLY=($(compgen -W "$containers" -- ${cur}))

--- a/contrib/completion/zsh/_lxdock
+++ b/contrib/completion/zsh/_lxdock
@@ -94,10 +94,10 @@ case $state in
         ;;
 
       (shell)
-        # lxdock shell [-h] [-u USERNAME] [name]
-        _arguments '(-u --username)'{-u,--username}'[Username to login as]:username:' \
-                   '::container:__container_list' \
-
+        # lxdock shell name [-h] [-u USERNAME] [-c ...]
+        _arguments '::container:__container_list' \
+                   '(-u --username)'{-u,--username}'[Username to login as]:username:' \
+                   '(-c --command)'{-c,--command}'[Command to be executed]:*command:command:'
         ;;
 
       (status)

--- a/docs/cli/shell.rst
+++ b/docs/cli/shell.rst
@@ -1,18 +1,20 @@
 lxdock shell
 ============
 
-**Command:** ``lxdock shell [arguments] [name]``
+**Command:** ``lxdock shell [name] [arguments]``
 
 This command can be used to open an interactive shell inside one of your containers.
+If ``-c`` is specified, execute the command line instead of opening the shell.
 
 By default, that shell logins as ``root`` unless your LXDock config specifies another user
-in its ``shell:`` option. In all cases, the ``--user`` command line overrides everything.
+in its ``shell`` option. In all cases, the ``--user`` command line overrides everything.
 
 Options
 -------
 
 * ``[name]`` - a container name
 * ``-u, --user <username>`` - user to login as
+* ``-c, --command <command_line>`` - command to be executed in the shell
 
 Examples
 --------
@@ -21,3 +23,8 @@ Examples
 
   $ lxdock shell mycontainer       # opens a shell into the "mycontainer" container
   $ lxdock shell -u root           # opens a shell as root, regardless of our config
+  $ lxdock shell mycontainer -c echo HELLO      # executes "echo HELLO" in "mycontainer"
+  $ lxdock shell mycontainer -c echo '$PATH'    # executes "echo '$PATH'" in "mycontainer"
+
+
+For the last example, you will see "$PATH" as-is. It is not evaluated as a variable.

--- a/docs/release_notes/v0.3.rst
+++ b/docs/release_notes/v0.3.rst
@@ -15,3 +15,5 @@ New features
 * Add support for variable interpolation in LXDock files
   (`#65 <https://github.com/lxdock/lxdock/pull/65>`_,
   `#75 <https://github.com/lxdock/lxdock/pull/75>`_)
+* Add support for passing a command line with ``lxdock shell``
+  (`#67 <https://github.com/lxdock/lxdock/pull/67>`_)

--- a/lxdock/cli/main.py
+++ b/lxdock/cli/main.py
@@ -74,11 +74,16 @@ class LXDock:
 
         # Creates the 'shell' action.
         self._parsers['shell'] = subparsers.add_parser(
-            'shell', help='Open a shell in a container.',
-            description='Open an interactive shell inside a specific container.')
+            'shell', help='Open a shell or execute a command in a container.',
+            description='Open an interactive shell inside a specific container. If a command is '
+                        'specified, execute the command instead.',
+            usage='lxdock shell [-h] [-u USERNAME] [name] [-c ...]')
         self._parsers['shell'].add_argument('name', nargs='?', help='Container name.')
         self._parsers['shell'].add_argument(
             '-u', '--username', help='Username to login as.')
+        self._parsers['shell'].add_argument(
+            '-c', '--command', nargs=argparse.REMAINDER, dest='cmd_args',
+            help='Command to be executed.')
 
         # Creates the 'status' action.
         self._parsers['status'] = subparsers.add_parser(
@@ -201,7 +206,8 @@ class LXDock:
         self.project.provision(container_names=args.name)
 
     def shell(self, args):
-        self.project.shell(container_name=args.name, username=args.username)
+        self.project.shell(
+            container_name=args.name, username=args.username, cmd_args=args.cmd_args)
 
     def status(self, args):
         self.project.status(container_names=args.name)

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -158,6 +158,17 @@ class TestProject(LXDTestCase):
         assert mocked_call.call_args[0][0] == \
             'lxc exec {} -- su -m root'.format(persistent_container.lxd_name)
 
+    @unittest.mock.patch('subprocess.call')
+    def test_can_run_shell_command_for_a_specific_container(
+            self, mocked_call, persistent_container):
+        homedir = os.path.join(FIXTURE_ROOT, 'project03')
+        project = Project('project02', homedir, self.client, [persistent_container, ])
+        project.shell(container_name='testcase-persistent', cmd_args=['echo', 'HELLO'])
+        assert mocked_call.call_count == 1
+        assert mocked_call.call_args[0][0] == \
+            "lxc exec {} -- su -m root -s {}".format(
+                persistent_container.lxd_name, persistent_container._guest_shell_script_file)
+
     @unittest.mock.patch.object(project_logger, 'info')
     def test_can_return_the_statuses_of_containers(self, mock_info, persistent_container):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -150,7 +150,8 @@ class TestLXDock:
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
         LXDock(['shell'])
         assert mock_project_shell.call_count == 1
-        assert mock_project_shell.call_args == [{'container_name': None, 'username': None}, ]
+        assert mock_project_shell.call_args == [{
+            'container_name': None, 'username': None, 'cmd_args': None}, ]
 
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'shell')
@@ -160,7 +161,8 @@ class TestLXDock:
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
         LXDock(['shell', 'c1'])
         assert mock_project_shell.call_count == 1
-        assert mock_project_shell.call_args == [{'container_name': 'c1', 'username': None}, ]
+        assert mock_project_shell.call_args == [{
+            'container_name': 'c1', 'username': None, 'cmd_args': None}, ]
 
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'shell')
@@ -169,7 +171,42 @@ class TestLXDock:
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
         LXDock(['shell', '-u', 'foobar'])
         assert mock_project_shell.call_count == 1
-        assert mock_project_shell.call_args == [{'container_name': None, 'username': 'foobar'}, ]
+        assert mock_project_shell.call_args == [{
+            'container_name': None, 'username': 'foobar', 'cmd_args': None}, ]
+
+    @unittest.mock.patch.object(LXDock, 'project')
+    @unittest.mock.patch.object(Project, 'shell')
+    def test_can_run_shell_command_for_a_specific_container(self, mock_project_shell, mock_project):
+        mock_project.__get__ = unittest.mock.Mock(
+            return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
+        LXDock(['shell', 'c1', '-c', 'echo', 'he re"s', '-u', '$PATH'])
+        assert mock_project_shell.call_count == 1
+        assert mock_project_shell.call_args == [{
+            'container_name': 'c1', 'username': None,
+            'cmd_args': ['echo', 'he re\"s', '-u', '$PATH']}, ]
+
+    @unittest.mock.patch.object(LXDock, 'project')
+    @unittest.mock.patch.object(Project, 'shell')
+    def test_can_run_shell_command_for_a_specific_user(self, mock_project_shell, mock_project):
+        mock_project.__get__ = unittest.mock.Mock(
+            return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
+        LXDock(['shell', '-u', 'foobar', '-c', 'echo', 'he re"s', '-u', '$PATH'])
+        assert mock_project_shell.call_count == 1
+        assert mock_project_shell.call_args == [{
+            'container_name': None, 'username': 'foobar',
+            'cmd_args': ['echo', 'he re\"s', '-u', '$PATH']}, ]
+
+    @unittest.mock.patch.object(LXDock, 'project')
+    @unittest.mock.patch.object(Project, 'shell')
+    def test_can_run_shell_command_for_a_specific_user_and_container(
+            self, mock_project_shell, mock_project):
+        mock_project.__get__ = unittest.mock.Mock(
+            return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
+        LXDock(['shell', '-u', 'foobar', 'c1', '-c', 'echo', 'he re"s', '-u', '$PATH'])
+        assert mock_project_shell.call_count == 1
+        assert mock_project_shell.call_args == [{
+            'container_name': 'c1', 'username': 'foobar',
+            'cmd_args': ['echo', 'he re\"s', '-u', '$PATH']}, ]
 
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'status')


### PR DESCRIPTION
After discussing with @ellmetha, #61 is implemented as an additional parameter `-c`:

```
lxdock shell [arguments] [name] [-c command_line]
```

The parameter `-c` should be placed at the last and it takes all remaining arguments as `command_line`. With a similar behavior of `docker exec` and `lxc exec`, the arguments are passed literally and not evaluated further by shell syntax:

```
$ docker exec 12dc5e75e5a6 echo "he re\"s" -u '$PATH'
he re"s -u $PATH

$ lxc exec test-linux-containers-gentoo-current-13382216 -- echo "he re\"s" -u '$PATH'
he re"s -u $PATH

$ lxdock shell gentoo-current -u localuser -c echo "he re\"s" -u '$PATH'
he re"s -u $PATH
```

The added dependency `shlex` in `lxdock/container.py` has previously existed in `lxdock/provisioners/shell.py`, so nothing changes regarding dependencies.

The bash and zsh completions are also updated. For bash, `-c, --command` is added besides `-u, --username`. But zsh is able to take all remaining arguments:
![image](https://cloud.githubusercontent.com/assets/8630726/25668256/34fca13e-2ff4-11e7-8718-d6eb3db0f9c4.png)

Related docs are updated.