### PR TITLE
New: Puppet provisioning (experimental support). Refs #37

### DIFF
--- a/docs/provisioners/index.rst
+++ b/docs/provisioners/index.rst
@@ -28,4 +28,5 @@ Documentation sections for the supported provisioning tools or methods are liste
     :maxdepth: 1
 
     ansible
+    puppet
     shell

--- a/docs/provisioners/puppet.rst
+++ b/docs/provisioners/puppet.rst
@@ -1,0 +1,93 @@
+#######
+Puppet
+#######
+
+LXDock provides built-in support for `Puppet`_ provisioning.
+
+.. _Puppet: https://puppet.com/
+
+
+Distribution Support
+--------------------
+
+Puppet provisioning requires the executable ``puppet`` in the guest container. For ArchLinux,
+Debian, Fedora and Ubuntu guests, LXDock tries to install the ``puppet`` package during
+``lxdock up``.
+
+However, the automatic installation may fail, it may install an old version of Puppet, or you
+may also use another Linux distribution. In these cases, you may see an error message at
+the beginning of ``lxdock provision`` or during the provisioning (due to version mismatch).
+You will have to check out the proper documentation for your Linux distribution and Puppet version,
+and add a shell provisioner in LXDock file before the Puppet provisioner. Here is an example for
+CentOS 7:
+
+.. code-block:: yaml
+
+  name: centos-7
+  image: centos/7
+
+  provisioning:
+    - type: shell
+      inline: sh -c 'rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm && yum -y install puppet'
+    - type: puppet
+      [...] # Puppet options
+
+By default, LXDock runs ``which puppet`` to find the executable. You may override this behavior
+by providing ``binary_path`` option and LXDock will then find ``puppet`` executable under that path.
+
+
+Usage
+-----
+
+Add a ``puppet`` provisioning operation to your LXDock file as follows:
+
+.. code-block:: yaml
+
+  name: myproject
+  image: ubuntu/xenial
+
+  provisioning:
+    - type: puppet
+      manifests_path: manifests
+      manifest_file: site.pp
+      module_path: modules
+      hiera_config_path: hiera.yaml
+      facter:
+          role: app
+          domain_name: app.example.com
+      options: "--verbose --debug"
+
+
+Puppet provisioning can be run in "manifest" mode or "environment" mode by setting ``manifests_path``
+or ``environment_path``, respectively. If ``manifest_file`` is not provided in "manifest" mode, it is
+given the default value ``default.pp``. If ``environment`` is not provided in "environment" mode, it
+is given ``production`` as the default value.
+
+If none of ``manifests_path`` and ``environment_path`` are given, LXDock assumes "manifest" mode and
+set ``manifests_path`` to ``manifests``. During the validation of an LXDock file, the existence of
+``manifests_path/manifest_file`` or ``environment_path/environment`` is checked.
+
+
+Options
+-------
+
+LXDock's Puppet provisioning is expected to reuse the files and configurations for a Vagrant project.
+This is still experimental, so if it doesn't work for your case, please feel free to create a GitHub
+issue!
+
+Here are the options that LXDock has supported:
+
+- ``binary_path``
+- ``facter``
+- ``hiera_config_path``
+- ``manifest_file``
+- ``manifests_path``
+- ``module_path``
+- ``environment``
+- ``environment_path``
+- ``environment_variables``
+- ``options``: LXDock takes a single string of space-separated options, instead of an array of strings.
+
+Please reference: `Vagrant docs`_
+
+.. _Vagrant docs: https://www.vagrantup.com/docs/provisioning/puppet_apply.html#options

--- a/docs/release_notes/v0.3.rst
+++ b/docs/release_notes/v0.3.rst
@@ -23,6 +23,8 @@ New features
   (`#77 <https://github.com/lxdock/lxdock/pull/77>`_)
 * Add a ``set_host_acl`` option to disable setting host ACL on a share
   (`#79 <https://github.com/lxdock/lxdock/pull/79>`_)
+* Add experimental support for Puppet provisioning
+  (`#69 <https://github.com/lxdock/lxdock/pull/69>`_)
 
 Minor changes
 -------------

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -1,55 +1,73 @@
-from voluptuous import All, Any, Coerce, Extra, In, IsDir, Length, Required, Schema, Url
+from voluptuous import (ALLOW_EXTRA, All, Any, Coerce, Extra, In, IsDir, Length, Required, Schema,
+                        Url)
 
 from ..provisioners import Provisioner
 
 from .validators import Hostname, LXDIdentifier
 
 
-_top_level_and_containers_common_options = {
-    'environment': {Extra: Coerce(str)},
-    'hostnames': [Hostname(), ],
-    'image': str,
-    'lxc_config': {Extra: str},
-    'mode': In(['local', 'pull', ]),
-    'privileged': bool,
-    'profiles': [str, ],
-    'protocol': In(['lxd', 'simplestreams', ]),
-    'provisioning': [],  # will be set dynamically using provisioner classes...
-    'server': Url(),
-    'shares': [{
-        # The existence of the source directory will be checked!
-        'source': IsDir(),
-        'dest': str,
-        'set_host_acl': bool,
-    }],
-    'shell': {
-        'user': str,
-        'home': str,
-    },
-    'users': [{
-        # Usernames max length is set 32 characters according to useradd's man page.
-        Required('name'): All(str, Length(max=32)),
-        'home': str,
-        'password': str,
-    }],
-}
+def get_schema():
+    _top_level_and_containers_common_options = {
+        'environment': {Extra: Coerce(str)},
+        'hostnames': [Hostname(), ],
+        'image': str,
+        'lxc_config': {Extra: str},
+        'mode': In(['local', 'pull', ]),
+        'privileged': bool,
+        'profiles': [str, ],
+        'protocol': In(['lxd', 'simplestreams', ]),
+        'provisioning': [],  # will be set dynamically using provisioner classes...
+        'server': Url(),
+        'shares': [{
+            # The existence of the source directory will be checked!
+            'source': IsDir(),
+            'dest': str,
+            'set_host_acl': bool,
+        }],
+        'shell': {
+            'user': str,
+            'home': str,
+        },
+        'users': [{
+            # Usernames max length is set 32 characters according to useradd's man page.
+            Required('name'): All(str, Length(max=32)),
+            'home': str,
+            'password': str,
+        }],
+    }
 
-# Inserts provisioner specific schema rules in the global schema dict.
-_top_level_and_containers_common_options['provisioning'] = [
-    Any(*[dict([(Required('type'), provisioner.name), ] + list(provisioner.schema.items()))
-          for provisioner in Provisioner.provisioners.values()]),
-]
+    def _check_provisioner_config(config):
+        provisioners = Provisioner.provisioners.values()
 
-_container_options = {
-    Required('name'): LXDIdentifier(),
-}
-_container_options.update(_top_level_and_containers_common_options)
+        # Check if 'type' is correctly defined
+        Schema({Required('type'): Any(*[provisioner.name for provisioner in provisioners])},
+               extra=ALLOW_EXTRA)(config)
 
-_lxdock_options = {
-    Required('name'): LXDIdentifier(),
-    'containers': [_container_options, ],
-}
-_lxdock_options.update(_top_level_and_containers_common_options)
+        # Check if the detected provisioner's schema is fully satisfied
+        c = config.copy()
+        name = c.pop('type')
+        detected_provisioner = next(provisioner for provisioner in provisioners
+                                    if provisioner.name == name)
+        validated = Schema(detected_provisioner.schema)(c)
+        validated['type'] = name
+        return validated
+
+    # Inserts provisioner specific schema rules in the global schema dict.
+    _top_level_and_containers_common_options['provisioning'] = [All(_check_provisioner_config)]
+
+    _container_options = {
+        Required('name'): LXDIdentifier(),
+    }
+    _container_options.update(_top_level_and_containers_common_options)
+
+    _lxdock_options = {
+        Required('name'): LXDIdentifier(),
+        'containers': [_container_options, ],
+    }
+    _lxdock_options.update(_top_level_and_containers_common_options)
+
+    return Schema(_lxdock_options)
+
 
 # The schema will be used to validate LXDock files!
-schema = Schema(_lxdock_options)
+schema = get_schema()

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -97,18 +97,29 @@ class Container:
         if barebone:
             self._perform_barebones_setup()
 
-        logger.info('Provisioning container "{name}"...'.format(name=self.name))
-
+        # Instantiate all provisioners
+        provisioners = []
         for provisioning_item in provisioning_steps:
             provisioning_type = provisioning_item['type'].lower()
             provisioner_class = Provisioner.provisioners.get(provisioning_type)
             if provisioner_class is not None:
                 provisioner = provisioner_class(
                     self.homedir, self._host, self._guest, provisioning_item)
-                logger.info('Provisioning with {0}'.format(provisioning_item['type']))
-                if barebone:
-                    provisioner.setup()
-                provisioner.provision()
+                provisioners.append(provisioner)
+
+        logger.info('Provisioning container "{name}"...'.format(name=self.name))
+
+        # Do barebone setups for each provisioner if necessary
+        if barebone:
+            for provisioner in provisioners:
+                logger.info('Performing barebones setup for provisioner {0}'.format(
+                    provisioner.name))
+                provisioner.setup()
+
+        # Provision
+        for provisioner in provisioners:
+            logger.info('Provisioning with {0}'.format(provisioner.name))
+            provisioner.provision()
 
         self._container.config['user.lxdock.provisioned'] = 'true'
         self._container.save(wait=True)

--- a/lxdock/exceptions.py
+++ b/lxdock/exceptions.py
@@ -9,3 +9,7 @@ class ProjectError(LXDockException):
 
 class ContainerOperationFailed(LXDockException):
     """ An operation on a specific container failed. """
+
+
+class ProvisionFailed(LXDockException):
+    """ A provisioning failed. """

--- a/lxdock/guests/base.py
+++ b/lxdock/guests/base.py
@@ -7,6 +7,9 @@
 
 import logging
 import re
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
 
 from pylxd.exceptions import NotFound
 
@@ -139,6 +142,37 @@ class Guest(with_metaclass(_GuestBase)):
         logger.debug(stdout)
         logger.debug(stderr)
         return exit_code
+
+    def copy_file(self, host_path, guest_path):
+        """
+        Copies a file from host_path (pathlib.Path) to guest_path (pathlib.PurePath).
+        Ensures `mkdir -p` before calling LXD file put.
+        """
+        self.run(['mkdir', '-p', str(guest_path.parent)])
+        with host_path.open('rb') as f:
+            logger.debug('Copying host:{} to guest:{}'.format(host_path, guest_path))
+            self.lxd_container.files.put(str(guest_path), f.read())
+
+    _guest_temporary_tar_path = '/.lxdock.d/copied_directory.tar'
+
+    def copy_directory(self, host_path, guest_path):
+        """
+        Copies a directory from host_path (pathlib.Path) to guest_path (pathlib.PurePath).
+        This is natively supported since LXD 2.2 but we have to support 2.0+
+        Refs: https://github.com/lxc/lxd/issues/2401
+
+        Uses tar to pack/unpack the directory.
+        """
+        guest_tar_path = self._guest_temporary_tar_path
+        self.run(['mkdir', '-p', str(guest_path)])
+        with tempfile.NamedTemporaryFile() as f:
+            logger.debug("Creating tar file from {}".format(host_path))
+            tar = tarfile.open(f.name, 'w')
+            tar.add(str(host_path), arcname='.')
+            tar.close()
+            self.copy_file(Path(f.name), PurePosixPath(guest_tar_path))
+        self.run(['tar', '-xf', guest_tar_path, '-C', str(guest_path)])
+        self.run(['rm', '-f', str(guest_tar_path)])
 
     ##################################
     # PRIVATE METHODS AND PROPERTIES #

--- a/lxdock/guests/debian.py
+++ b/lxdock/guests/debian.py
@@ -7,4 +7,5 @@ class DebianGuest(Guest):
     name = 'debian'
 
     def install_packages(self, packages):
+        self.run(['apt-get', 'update'])
         self.run(['apt-get', 'install', '-y'] + packages)

--- a/lxdock/provisioners/__init__.py
+++ b/lxdock/provisioners/__init__.py
@@ -7,4 +7,5 @@
 
 from .ansible import *  # noqa
 from .base import *  # noqa
+from .puppet import *  # noqa
 from .shell import *  # noqa

--- a/lxdock/provisioners/puppet.py
+++ b/lxdock/provisioners/puppet.py
@@ -1,0 +1,201 @@
+import logging
+import shlex
+from pathlib import Path, PurePosixPath
+
+from voluptuous import All, IsDir, IsFile
+
+from ..exceptions import ProvisionFailed
+from .base import Provisioner
+
+
+__all__ = ('PuppetProvisioner', )
+
+logger = logging.getLogger(__name__)
+
+
+def finalize_options(options):
+    # Refs Vagrant code:
+    # https://github.com/mitchellh/vagrant/blob/9c299a2a357fcf87f356bb9d56e18a037a53d138/
+    #         plugins/provisioners/puppet/config/puppet.rb#L58
+    if options.get('environment_path') is None and options.get('manifests_path') is None:
+        logger.warn("environment_path and manifests_path are both unset, "
+                    "assuming manifests mode and manifests_path as 'manifests'...")
+        options['manifests_path'] = 'manifests'
+
+    if options.get('environment_path') is None:
+        if options.get('manifest_file') is None:
+            logger.warn("manifest_file is not set. Assuming 'default.pp'...")
+            options['manifest_file'] = 'default.pp'
+    else:
+        if options.get('environment') is None:
+            logger.warn("environment is not set. Assuming 'production'...")
+            options['environment'] = 'production'
+
+    return options
+
+
+def validate_paths(options):
+    # Refs Vagrant code:
+    # https://github.com/mitchellh/vagrant/blob/9c299a2a357fcf87f356bb9d56e18a037a53d138/
+    #         plugins/provisioners/puppet/config/puppet.rb#L112
+    if options.get('manifests_path') is not None:
+        host_manifest_file = str(
+            Path(options['manifests_path']) / options['manifest_file'])
+        IsFile(msg="File {} does not exist".format(host_manifest_file))(host_manifest_file)
+    elif options.get('environment_path') is not None:
+        host_selected_environment_path = str(
+            Path(options['environment_path']) / options['environment'])
+        IsDir(msg="Directory {} does not exist".format(host_selected_environment_path))(
+            host_selected_environment_path)
+    return options
+
+
+class PuppetProvisioner(Provisioner):
+    """ Allows to perform provisioning operations using Puppet. """
+
+    name = 'puppet'
+
+    guest_required_packages_arch = ['puppet']
+    guest_required_packages_debian = ['puppet']
+    guest_required_packages_fedora = ['puppet']
+    guest_required_packages_ubuntu = ['puppet']
+
+    # Refs Vagrant docs:
+    # https://www.vagrantup.com/docs/provisioning/puppet_apply.html#options
+    schema = All({
+        'binary_path': str,
+        'facter': dict,
+        'hiera_config_path': IsFile(),
+        'manifest_file': str,
+        'manifests_path': IsDir(),
+        'module_path': IsDir(),
+        'environment': str,
+        'environment_path': IsDir(),
+        'environment_variables': dict,
+        'options': str,
+    }, finalize_options, validate_paths)
+
+    _guest_manifests_path = '/.lxdock.d/puppet/manifests'
+    _guest_module_path = '/.lxdock.d/puppet/modules'
+    _guest_default_module_path = '/etc/puppet/modules'
+    _guest_environment_path = '/.lxdock.d/puppet/environments'
+    _guest_hiera_file = '/.lxdock.d/puppet/hiera.yaml'
+
+    def provision(self):
+        """ Performs the provisioning operations using puppet. """
+        # Verify if `puppet` has been installed.
+        binary_path = self.options.get('binary_path')
+        if binary_path is not None:
+            puppet_bin = str(PurePosixPath(binary_path) / 'puppet')
+            retcode = self.guest.run(['test', '-x', puppet_bin])
+            fail_msg = (
+                "puppet executable is not found in the specified path {} in the "
+                "guest container. ".format(binary_path)
+            )
+        else:
+            retcode = self.guest.run(['which', 'puppet'])
+            fail_msg = (
+                "puppet was not automatically installed for this guest. "
+                "Please specify the command to install it in LXDock file using "
+                "a shell provisioner and try `lxdock provision` again. You may "
+                "also specify `binary_path` that contains the puppet executable "
+                "in LXDock file.")
+        if retcode != 0:
+            raise ProvisionFailed(fail_msg)
+
+        # Copy manifests dir
+        manifests_path = self.options.get('manifests_path')
+        if manifests_path is not None:
+            self.guest.copy_directory(
+                Path(manifests_path), PurePosixPath(self._guest_manifests_path))
+
+        # Copy module dir
+        module_path = self.options.get('module_path')
+        if module_path is not None:
+            self.guest.copy_directory(Path(module_path), PurePosixPath(self._guest_module_path))
+
+        # Copy environment dir
+        environment_path = self.options.get('environment_path')
+        if environment_path is not None:
+            self.guest.copy_directory(
+                Path(environment_path), PurePosixPath(self._guest_environment_path))
+
+        # Copy hiera file
+        hiera_file = self.options.get('hiera_config_path')
+        if hiera_file is not None:
+            self.guest.copy_file(Path(hiera_file), PurePosixPath(self._guest_hiera_file))
+
+        # Run puppet.
+        command = self._build_puppet_command()
+
+        if environment_path:
+            logger.info("Running Puppet with environment {}...".format(self.options['environment']))
+        else:
+            logger.info("Running Puppet with {}...".format(self.options['manifest_file']))
+
+        self.guest.run(['sh', '-c', ' '.join(command)])
+
+    ##################################
+    # PRIVATE METHODS AND PROPERTIES #
+    ##################################
+
+    def _build_puppet_command(self):
+        """
+        Refs:
+        https://github.com/mitchellh/vagrant/blob/9c299a2a357fcf87f356bb9d56e18a037a53d138/
+                plugins/provisioners/puppet/provisioner/puppet.rb#L173
+        """
+
+        options = self.options.get('options', '')
+        options = list(map(shlex.quote, shlex.split(options)))
+
+        module_path = self.options.get('module_path')
+        if module_path is not None:
+            options += ['--modulepath',
+                        '{}:{}'.format(self._guest_module_path,
+                                       self._guest_default_module_path)]
+
+        hiera_path = self.options.get('hiera_config_path')
+        if hiera_path is not None:
+            options += ['--hiera_config={}'.format(self._guest_hiera_file)]
+
+        # TODO: we are not detecting console color support now, but please contribute if you need!
+
+        options += ['--detailed-exitcodes']
+
+        environment_path = self.options.get('environment_path')
+        if environment_path is not None:
+            options += ['--environmentpath', str(self._guest_environment_path),
+                        '--environment', self.options['environment']]
+        else:
+            options += ['--manifestdir', str(self._guest_manifests_path)]
+
+        manifest_file = self.options.get('manifest_file')
+        if manifest_file is not None:
+            options += [str(
+                PurePosixPath(self._guest_manifests_path) / manifest_file)]
+
+        # Build up the custom facts if we have any
+        facter = []
+        facter_dict = self.options.get('facter')
+        if facter_dict is not None:
+            for key, value in sorted(facter_dict.items()):
+                facter.append("FACTER_{}={}".format(key, shlex.quote(value)))
+
+        binary_path = self.options.get('binary_path')
+        if binary_path is not None:
+            puppet_bin = str(PurePosixPath(binary_path) / 'puppet')
+        else:
+            puppet_bin = 'puppet'
+
+        # TODO: working_directory for hiera. Please contribute!
+
+        env = []
+        env_variables = self.options.get('environment_variables')
+        if env_variables is not None:
+            for key, value in sorted(env_variables.items()):
+                env.append("{}={}".format(key, shlex.quote(value)))
+
+        command = env + facter + [puppet_bin, 'apply'] + options
+
+        return command

--- a/tests/unit/conf/test_schema.py
+++ b/tests/unit/conf/test_schema.py
@@ -1,0 +1,84 @@
+import unittest.mock
+
+import pytest
+from voluptuous import All, Any, Boolean, Coerce, Length
+from voluptuous.error import Invalid
+
+from lxdock.conf.schema import get_schema
+
+
+class MockProvisioner1(object):
+    name = 'mp1'
+    schema = {'a': str, 'b': Coerce(int)}
+
+
+class MockProvisioner2(object):
+    name = 'mp2'
+    schema = All({'a': str}, {'a': Length(min=5, max=5)})
+
+
+class MockProvisioner3(object):
+    name = 'mp3'
+    schema = Any({'a': str}, {'b': Boolean()})
+
+
+class TestValidateProvisionerSchemas:
+    @unittest.mock.patch('lxdock.conf.schema.Provisioner')
+    def test_can_validate_and_coerce_multiple_provisioner_schemas(self, mock_Provisioner):
+        mock_Provisioner.provisioners = {
+            'mp1': MockProvisioner1,
+            'mp2': MockProvisioner2,
+            'mp3': MockProvisioner3}
+        schema = get_schema()
+        validated = schema({
+            'name': 'dummy-test',
+            'provisioning': [{
+                'type': 'mp1',
+                'a': 'dummy',
+                'b': '16'
+            }, {
+                'type': 'mp2',
+                'a': 'dummy',
+            }, {
+                'type': 'mp3',
+                'b': 'yes'
+            }]
+        })
+        assert validated == {
+            'name': 'dummy-test',
+            'provisioning': [{
+                'type': 'mp1',
+                'a': 'dummy',
+                'b': 16  # Check Coerce
+            }, {
+                'type': 'mp2',
+                'a': 'dummy',
+            }, {
+                'type': 'mp3',
+                'b': True  # Check Boolean
+            }]
+        }
+
+    @unittest.mock.patch('lxdock.conf.schema.Provisioner')
+    def test_raise_invalid_if_provisioner_schema_is_not_satisfied(self, mock_Provisioner):
+        mock_Provisioner.provisioners = {
+            'mp1': MockProvisioner1,
+            'mp2': MockProvisioner2,
+            'mp3': MockProvisioner3}
+        schema = get_schema()
+        with pytest.raises(Invalid) as e:
+            schema({
+                'name': 'dummy-test',
+                'provisioning': [{
+                    'type': 'mp1',
+                    'a': 'dummy',
+                    'b': '16'
+                }, {
+                    'type': 'mp2',
+                    'a': 'dummydummy',  # Exceeds Length(min=5, max=5)
+                }, {
+                    'type': 'mp3',
+                    'b': 'yes'
+                }]
+            })
+        assert "['provisioning'][1]['a']" in str(e)

--- a/tests/unit/guests/test_debian.py
+++ b/tests/unit/guests/test_debian.py
@@ -9,6 +9,8 @@ class TestDebianGuest:
         lxd_container.execute.return_value = ('ok', 'ok', '')
         guest = DebianGuest(lxd_container)
         guest.install_packages(['python', 'openssh', ])
-        assert lxd_container.execute.call_count == 1
-        assert lxd_container.execute.call_args[0] == \
+        assert lxd_container.execute.call_count == 2
+        assert lxd_container.execute.call_args_list[0][0] == \
+            (['apt-get', 'update', ], )
+        assert lxd_container.execute.call_args_list[1][0] == \
             (['apt-get', 'install', '-y', 'python', 'openssh', ], )

--- a/tests/unit/provisioners/test_base.py
+++ b/tests/unit/provisioners/test_base.py
@@ -33,8 +33,10 @@ class TestProvisioner:
         guest = DebianGuest(lxd_container)
         provisioner = DummyProvisioner('./', host, guest, {})
         provisioner.setup()
-        assert lxd_container.execute.call_count == 1
-        assert lxd_container.execute.call_args[0] == \
+        assert lxd_container.execute.call_count == 2
+        assert lxd_container.execute.call_args_list[0][0] == \
+            (['apt-get', 'update'], )
+        assert lxd_container.execute.call_args_list[1][0] == \
             (['apt-get', 'install', '-y', 'test01', 'test02', ], )
 
     def test_trigger_specific_setup_on_the_guest_if_the_related_method_is_defined(self):

--- a/tests/unit/provisioners/test_puppet.py
+++ b/tests/unit/provisioners/test_puppet.py
@@ -1,0 +1,266 @@
+import os
+import tempfile
+import unittest.mock
+from pathlib import Path, PurePosixPath
+
+import pytest
+from voluptuous import Schema
+from voluptuous.error import Invalid
+
+from lxdock.exceptions import ProvisionFailed
+from lxdock.guests import Guest
+from lxdock.hosts import Host
+from lxdock.provisioners import PuppetProvisioner
+
+
+class TestPuppetProvisionerSchema:
+    def test_can_set_default_manifest_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            with (Path(d) / 'default.pp').open('w') as f:
+                f.write('dummy pp file')
+            config = {'manifests_path': d}
+            try:
+                final_config = Schema(PuppetProvisioner.schema)(config)
+            except Invalid as e:
+                pytest.fail("schema validation didn't pass: {}".format(e))
+            assert final_config == {
+                'manifest_file': 'default.pp',
+                'manifests_path': d}
+
+    def test_can_set_default_environment(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.mkdir(str(Path(d) / 'production'))
+            config = {'environment_path': d}
+            try:
+                final_config = Schema(PuppetProvisioner.schema)(config)
+            except Invalid as e:
+                pytest.fail("schema validation didn't pass: {}".format(e))
+            assert final_config == {
+                'environment': 'production',
+                'environment_path': d}
+
+    @unittest.mock.patch('lxdock.provisioners.puppet.IsDir')
+    @unittest.mock.patch('lxdock.provisioners.puppet.IsFile')
+    def test_can_set_default_mode_and_manifest_file(self, mock_isfile, mock_isdir):
+        config = {}
+        try:
+            final_config = Schema(PuppetProvisioner.schema)(config)
+        except Invalid as e:
+            pytest.fail("schema validation didn't pass: {}".format(e))
+        assert final_config == {
+            'manifests_path': 'manifests',
+            'manifest_file': 'default.pp'}
+
+
+class TestPuppetProvisioner:
+    @unittest.mock.patch.object(Guest, 'copy_directory')
+    @unittest.mock.patch.object(Guest, 'run')
+    def test_can_run_puppet_manifest_mode(self, mock_run, mock_copy_dir):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        host = Host(unittest.mock.Mock())
+        guest = DummyGuest(unittest.mock.Mock())
+        mock_run.return_value = 0
+        provisioner = PuppetProvisioner('./', host, guest, {
+            'manifest_file': 'test_site.pp',
+            'manifests_path': 'test_manifests'})
+        provisioner.provision()
+
+        assert mock_copy_dir.call_count == 1
+        assert mock_copy_dir.call_args_list[0][0][0] == Path('test_manifests')
+        assert mock_copy_dir.call_args_list[0][0][1] == PurePosixPath(
+            provisioner._guest_manifests_path)
+
+        assert mock_run.call_count == 2
+        assert mock_run.call_args_list[0][0][0] == ['which', 'puppet']
+        assert mock_run.call_args_list[1][0][0] == [
+            'sh', '-c',
+            'puppet apply --detailed-exitcodes --manifestdir {} {}'.format(
+                PurePosixPath(provisioner._guest_manifests_path),
+                PurePosixPath(provisioner._guest_manifests_path) / 'test_site.pp')]
+
+    @unittest.mock.patch.object(Guest, 'copy_directory')
+    @unittest.mock.patch.object(Guest, 'run')
+    def test_can_run_puppet_environment_mode(self, mock_run, mock_copy_dir):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        host = Host(unittest.mock.Mock())
+        guest = DummyGuest(unittest.mock.Mock())
+        mock_run.return_value = 0
+        provisioner = PuppetProvisioner('./', host, guest, {
+            'environment': 'test_production',
+            'environment_path': 'test_environments'})
+        provisioner.provision()
+
+        assert mock_copy_dir.call_count == 1
+        assert mock_copy_dir.call_args_list[0][0][0] == Path('test_environments')
+        assert mock_copy_dir.call_args_list[0][0][1] == PurePosixPath(
+            provisioner._guest_environment_path)
+
+        assert mock_run.call_count == 2
+        assert mock_run.call_args_list[0][0][0] == ['which', 'puppet']
+        assert mock_run.call_args_list[1][0][0] == [
+            'sh', '-c',
+            'puppet apply --detailed-exitcodes '
+            '--environmentpath {} --environment {}'.format(
+                PurePosixPath(provisioner._guest_environment_path),
+                'test_production')]
+
+    @unittest.mock.patch.object(Guest, 'copy_file')
+    @unittest.mock.patch.object(Guest, 'run')
+    def test_raise_error_if_puppet_is_not_found(self, mock_run, mock_copy_file):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        host = Host(unittest.mock.Mock())
+        guest = DummyGuest(unittest.mock.Mock())
+        mock_run.return_value = 1  # Mock the error
+        provisioner = PuppetProvisioner('./', host, guest, {
+            'manifest_file': 'test_site.pp',
+            'manifests_path': 'test_manifests'})
+        with pytest.raises(ProvisionFailed):
+            provisioner.provision()
+        assert mock_run.call_count == 1
+        assert mock_run.call_args[0] == (['which', 'puppet'], )
+        assert mock_copy_file.call_count == 0
+
+    @unittest.mock.patch.object(Guest, 'copy_directory')
+    @unittest.mock.patch.object(Guest, 'run')
+    def test_can_set_binary_path(self, mock_run, mock_copy_dir):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        host = Host(unittest.mock.Mock())
+        guest = DummyGuest(unittest.mock.Mock())
+        mock_run.return_value = 0
+        provisioner = PuppetProvisioner('./', host, guest, {
+            'manifest_file': 'test_site.pp',
+            'manifests_path': 'test_manifests',
+            'binary_path': '/test/path'})
+        provisioner.provision()
+
+        assert mock_run.call_count == 2
+        assert mock_run.call_args_list[0][0][0] == ['test', '-x', '/test/path/puppet']
+        assert mock_run.call_args_list[1][0][0] == [
+            'sh', '-c',
+            '/test/path/puppet apply --detailed-exitcodes --manifestdir {} {}'.format(
+                PurePosixPath(provisioner._guest_manifests_path),
+                PurePosixPath(provisioner._guest_manifests_path) / 'test_site.pp')]
+
+    @unittest.mock.patch.object(Guest, 'copy_directory')
+    @unittest.mock.patch.object(Guest, 'run')
+    def test_can_set_facter(self, mock_run, mock_copy_dir):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        host = Host(unittest.mock.Mock())
+        guest = DummyGuest(unittest.mock.Mock())
+        mock_run.return_value = 0
+        provisioner = PuppetProvisioner('./', host, guest, {
+            'manifest_file': 'site.pp',
+            'manifests_path': 'test_manifests',
+            'facter': {'foo': 'bah', 'bar': 'baz baz'}})
+        provisioner.provision()
+        assert mock_run.call_count == 2
+        assert mock_run.call_args_list[1][0][0] == [
+            'sh', '-c',
+            "FACTER_bar='baz baz' FACTER_foo=bah "
+            "puppet apply --detailed-exitcodes --manifestdir {} {}".format(
+                PurePosixPath(provisioner._guest_manifests_path),
+                PurePosixPath(provisioner._guest_manifests_path) / 'site.pp')]
+
+    @unittest.mock.patch.object(Guest, 'copy_file')
+    @unittest.mock.patch.object(Guest, 'copy_directory')
+    @unittest.mock.patch.object(Guest, 'run')
+    def test_can_set_hiera_config_path(self, mock_run, mock_copy_dir, mock_copy_file):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        host = Host(unittest.mock.Mock())
+        guest = DummyGuest(unittest.mock.Mock())
+        mock_run.return_value = 0
+        provisioner = PuppetProvisioner('./', host, guest, {
+            'manifest_file': 'site.pp',
+            'manifests_path': 'test_manifests',
+            'hiera_config_path': 'hiera.yaml'})
+        provisioner.provision()
+
+        assert mock_copy_file.call_count == 1
+        assert mock_copy_file.call_args_list[0][0][0] == Path('hiera.yaml')
+        assert mock_copy_file.call_args_list[0][0][1] == PurePosixPath(
+            provisioner._guest_hiera_file)
+
+        assert mock_run.call_count == 2
+        assert mock_run.call_args_list[1][0][0] == [
+            'sh', '-c',
+            "puppet apply --hiera_config={} --detailed-exitcodes --manifestdir {} {}".format(
+                PurePosixPath(provisioner._guest_hiera_file),
+                PurePosixPath(provisioner._guest_manifests_path),
+                PurePosixPath(provisioner._guest_manifests_path) / 'site.pp')]
+
+    @unittest.mock.patch.object(Guest, 'copy_directory')
+    @unittest.mock.patch.object(Guest, 'run')
+    def test_can_set_module_path(self, mock_run, mock_copy_dir):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        host = Host(unittest.mock.Mock())
+        guest = DummyGuest(unittest.mock.Mock())
+        mock_run.return_value = 0
+        provisioner = PuppetProvisioner('./', host, guest, {
+            'manifest_file': 'mani.pp',
+            'manifests_path': 'test_manifests',
+            'module_path': 'test-puppet-modules'})
+        provisioner.provision()
+
+        assert mock_copy_dir.call_count == 2
+        assert (Path('test-puppet-modules'),
+                PurePosixPath(provisioner._guest_module_path)) in {
+                    mock_copy_dir.call_args_list[0][0],
+                    mock_copy_dir.call_args_list[1][0]}
+
+        assert mock_run.call_count == 2
+        assert mock_run.call_args_list[1][0][0] == [
+            'sh', '-c',
+            "puppet apply --modulepath {}:{} --detailed-exitcodes --manifestdir {} {}".format(
+                PurePosixPath(provisioner._guest_module_path),
+                PurePosixPath(provisioner._guest_default_module_path),
+                PurePosixPath(provisioner._guest_manifests_path),
+                PurePosixPath(provisioner._guest_manifests_path) / 'mani.pp')]
+
+    @unittest.mock.patch.object(Guest, 'copy_directory')
+    @unittest.mock.patch.object(Guest, 'run')
+    def test_can_set_environment_variables(self, mock_run, mock_copy_dir):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        host = Host(unittest.mock.Mock())
+        guest = DummyGuest(unittest.mock.Mock())
+        mock_run.return_value = 0
+        provisioner = PuppetProvisioner('./', host, guest, {
+            'manifest_file': 'site.pp',
+            'manifests_path': 'test_manifests',
+            'environment_variables': {'FOO': 'bah', 'BAR': 'baz baz'}})
+        provisioner.provision()
+        assert mock_run.call_count == 2
+        assert mock_run.call_args_list[1][0][0] == [
+            'sh', '-c',
+            "BAR='baz baz' FOO=bah "
+            "puppet apply --detailed-exitcodes --manifestdir {} {}".format(
+                PurePosixPath(provisioner._guest_manifests_path),
+                PurePosixPath(provisioner._guest_manifests_path) / 'site.pp')]
+
+    @unittest.mock.patch.object(Guest, 'copy_directory')
+    @unittest.mock.patch.object(Guest, 'run')
+    def test_can_set_options(self, mock_run, mock_copy_dir):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        host = Host(unittest.mock.Mock())
+        guest = DummyGuest(unittest.mock.Mock())
+        mock_run.return_value = 0
+        provisioner = PuppetProvisioner('./', host, guest, {
+            'manifest_file': 'site.pp',
+            'manifests_path': 'test_manifests',
+            'options': '--a --c="test space" --b'})
+        provisioner.provision()
+        assert mock_run.call_count == 2
+        assert mock_run.call_args_list[1][0][0] == [
+            'sh', '-c',
+            """puppet apply --a '--c=test space' --b """
+            """--detailed-exitcodes --manifestdir {} {}""".format(
+                PurePosixPath(provisioner._guest_manifests_path),
+                PurePosixPath(provisioner._guest_manifests_path) / 'site.pp')]


### PR DESCRIPTION
This pull request adds puppet provisioning support for LXDock, tested with [this lxdock.yml and site.pp](https://gist.github.com/lingxiaoyang/83dc9291073876342bbb6f54488f685f). 

New module: `lxdock.provisioners.puppet.PuppetProvisioner`.

It is implemented with the intention to mimic Vagrant's Puppet provisioning. The options are taken from [Vagrant doc](https://www.vagrantup.com/docs/provisioning/puppet_apply.html#options) and the usage of `puppet apply` command is taken from [Vagrant implementation](https://github.com/mitchellh/vagrant/blob/9c299a2a357fcf87f356bb9d56e18a037a53d138/plugins/provisioners/puppet/provisioner/puppet.rb#L173).

New public methods: `Guest.copy_file(host_path, guest_path)` and `Guest.copy_directory(host_path, guest_path)` (uses `pathlib` that exists since Python 3.4)