### PR TITLE
Enhancement: support shell patterns on `inline` option of shell provisioner

### DIFF
--- a/docs/provisioners/shell.rst
+++ b/docs/provisioners/shell.rst
@@ -17,16 +17,12 @@ Just append a ``shell`` provisioning operation to your LXDock file as follows:
 
   provisioning:
     - type: shell
-      inline: echo "Hello, World!"
+      inline: cd /tmp && echo "Here's the PATH" $$PATH >> test.txt
 
 .. note::
 
-  Keep in mind that the shell provisioner will use the LXD's ``exec`` method in order to run your
-  commands on containers (the same method used by the ``lxc exec`` command). This means that common
-  shell patterns (like file redirects, ``|``, ``>``, ``<``, ...) won't work because the ``exec``
-  method doesn't use a shell (so the kernel will not be able to understand these shell patterns).
-  The only way to overcome this is to put things like ``sh -c 'ls -l > /tmp/test'`` in your
-  ``inline`` options.
+  The inline command is executed by ``sh -c 'command_line'``. Keep in mind that dollar sign ``$``
+  means string interpolation in YAML and it is necessary to put ``$$`` to escape the dollar sign.
 
 Required options
 ----------------

--- a/docs/release_notes/v0.3.rst
+++ b/docs/release_notes/v0.3.rst
@@ -15,3 +15,5 @@ New features
 * Add support for variable interpolation in LXDock files
   (`#65 <https://github.com/lxdock/lxdock/pull/65>`_,
   `#75 <https://github.com/lxdock/lxdock/pull/75>`_)
+* Add support for shell patterns on the ``inline`` option of shell provisioner
+  (`#70 <https://github.com/lxdock/lxdock/pull/70>`_)

--- a/lxdock/hosts/base.py
+++ b/lxdock/hosts/base.py
@@ -8,6 +8,7 @@
 import logging
 import os
 import platform
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -124,6 +125,6 @@ class Host(with_metaclass(_HostBase)):
 
     def run(self, cmd_args):
         """ Runs the specified command on the host. """
-        cmd = ' '.join(cmd_args)
+        cmd = ' '.join(map(shlex.quote, cmd_args))
         logger.debug('Running {0} on the host'.format(cmd))
         subprocess.Popen(cmd, shell=True).wait()

--- a/lxdock/provisioners/shell.py
+++ b/lxdock/provisioners/shell.py
@@ -1,5 +1,4 @@
 import os
-import shlex
 
 from voluptuous import Any, Exclusive, IsFile
 
@@ -33,7 +32,7 @@ class ShellProvisioner(Provisioner):
         elif 'inline' in self.options:
             # Final case: we run a command directly inside the container or outside.
             host_or_guest = getattr(self, self._side)
-            host_or_guest.run(shlex.split(self.options['inline']))
+            host_or_guest.run(['sh', '-c', self.options['inline']])
 
     ##################################
     # PRIVATE METHODS AND PROPERTIES #

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -71,7 +71,7 @@ class TestContainer(LXDTestCase):
         persistent_container.halt()
         assert persistent_container._container.status_code == constants.CONTAINER_STOPPED
 
-    def test_can_provision_a_container(self):
+    def test_can_provision_a_container_ansible(self):
         container_options = {
             'name': self.containername('willprovision'), 'image': 'ubuntu/xenial', 'mode': 'pull',
             'provisioning': [
@@ -83,6 +83,21 @@ class TestContainer(LXDTestCase):
         container.up()
         assert container._container.config['user.lxdock.provisioned'] == 'true'
         assert container._container.files.get('/dummytest').strip() == b'dummytest'
+
+    def test_can_provision_a_container_shell_inline(self):
+        container_options = {
+            'name': self.containername('willprovision'), 'image': 'ubuntu/xenial', 'mode': 'pull',
+            'environment': {'PATH': '/dummy_test:/bin:/usr/bin:/usr/local/bin'},
+            'provisioning': [
+                {'type': 'shell',
+                 'inline': """touch f && echo "Here's the PATH" $PATH >> /tmp/test.txt""", }
+            ],
+        }
+        container = Container('myproject', THIS_DIR, self.client, **container_options)
+        container.up()
+        assert container._container.config['user.lxdock.provisioned'] == 'true'
+        assert container._container.files.get('/tmp/test.txt').strip() == (
+            b"Here's the PATH /dummy_test:/bin:/usr/bin:/usr/local/bin")
 
     @unittest.mock.patch('subprocess.call')
     def test_can_open_a_shell_for_the_root_user(self, mocked_call, persistent_container):


### PR DESCRIPTION
This pull request proposes the support for shell patterns in inline shell provisioning commands.

Changes proposed:
1. For shell provisioner's `inline` command, use `sh -c 'command_line'` instead of `lxc exec` to always let the shell run the command. The documentation is updated.
2. In `Host.run(cmd_args)`, apply `shlex.quote` on each arguments before joining them with spaces. This will prevent unexpected behaviors caused by a simple space-joining.
