### PR TITLE
Use stricter variable substitution

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -126,7 +126,7 @@ And then use it in your LXDock file as follows:
   mode: local
 
 lxc_config
------------
+----------
 
 If your container needs custom configuration settings, you can use ``lxc_config`` to pass any arbitrary
 key-value pairs that you want to be assigned to the container at startup. ``lxc_config`` must be a dictionary
@@ -286,7 +286,7 @@ for more information:
     - name: test02
       home: /opt/test02
     - name: test03
-      password: $$6$$cGzZBkDjOhGW$$6C9wwqQteFEY4lQ6ZJBggE568SLSS7bIMKexwOD39mJQrJcZ5vIKJVIfwsKOZajhbPw0.Zqd0jU2NDLAnp9J/1
+      password: $6$cGzZBkDjOhGW$6C9wwqQteFEY4lQ6ZJBggE568SLSS7bIMKexwOD39mJQrJcZ5vIKJVIfwsKOZajhbPw0.Zqd0jU2NDLAnp9J/1
 
 Variable substitution
 #####################
@@ -317,11 +317,6 @@ could create a LXDock file which looks like:
 When processing this file, LXDock will look for the ``USER`` environment variable (which can be
 defined either in your host's environment variables or in a ``.env`` file) and will substitute its
 variable in.
-
-Both following syntaxes are supported for variables: ``${VAR}`` and ``$VAR``. You may want to insert
-a literal dollar sign into your LXDock config file (in the case where you have to use static values
-containing dollar signs) ; in that case you should use a double-dollar sign (``$$``) to prevent
-LXDock from trying to interpolate the corresponding value.
 
 Where to put variables
 ----------------------

--- a/lxdock/conf/interpolation.py
+++ b/lxdock/conf/interpolation.py
@@ -1,4 +1,22 @@
+import re
 from string import Template
+
+
+class ConfigTemplate(Template):
+    """ Like string.Template except that only variables in the format
+    ${var} are supported but not the unbraced format of $var.
+
+    The stricter format allows $ characters to be used more easily in
+    the lxdock.yml file without having to escape them.
+    """
+    pattern = r"""
+    %(delim)s(?:
+      {(?P<braced>%(id)s)}  |  # delimiter and a braced identifier
+      {(?P<named>%(id)s)}   |  # delimiter and a Python identifier (not needed)
+      (?P<escaped>)         |  # Escape sequence (not needed)
+      (?P<invalid>)            # Other ill-formed delimiter exprs
+    )
+    """ % dict(delim=re.escape(Template.delimiter), id=Template.idpattern)
 
 
 def interpolate_variables(config_dict, mapping):
@@ -6,14 +24,14 @@ def interpolate_variables(config_dict, mapping):
 
     :param config_dict: dictionary containing the configuration values
     :param mapping: dictionary containing the available variables
-    :type arg1: dict
-    :type arg1: dict
+    :type config_dict: dict
+    :type mapping: dict
     :return: dictionary containing the interpolated config
     :rtype: dict
     """
     def interpolate(value):
         if isinstance(value, str):
-            return Template(value).substitute(**mapping)
+            return ConfigTemplate(value).substitute(**mapping)
         elif isinstance(value, dict):
             return {k: interpolate(v) for k, v in value.items()}
         elif isinstance(value, (list, tuple)):

--- a/tests/unit/conf/fixtures/project_with_dynamic_variables/lxdock.yml
+++ b/tests/unit/conf/fixtures/project_with_dynamic_variables/lxdock.yml
@@ -5,6 +5,4 @@ provisioning:
   - type: shell
     inline: touch /opt/${DUMMY_VAR_01}
   - type: shell
-    inline: touch /opt/$DUMMY_VAR_02
-  - type: shell
-    inline: echo $$thisisatest
+    inline: echo $thisisatest

--- a/tests/unit/conf/fixtures/project_with_dynamic_variables_and_env_file/.env
+++ b/tests/unit/conf/fixtures/project_with_dynamic_variables_and_env_file/.env
@@ -1,6 +1,5 @@
 # This is a comment!
 
 DUMMY_VAR_01 = test01
-DUMMY_VAR_02 = test02
 
 EMPTY=

--- a/tests/unit/conf/fixtures/project_with_dynamic_variables_and_env_file/lxdock.yml
+++ b/tests/unit/conf/fixtures/project_with_dynamic_variables_and_env_file/lxdock.yml
@@ -5,6 +5,4 @@ provisioning:
   - type: shell
     inline: touch /opt/${DUMMY_VAR_01}
   - type: shell
-    inline: touch /opt/$DUMMY_VAR_02
-  - type: shell
-    inline: echo $$thisisatest
+    inline: echo $thisisatest

--- a/tests/unit/conf/test_config.py
+++ b/tests/unit/conf/test_config.py
@@ -88,18 +88,15 @@ class TestConfig:
         env = EnvironmentVarGuard()
         with env:
             env.set('DUMMY_VAR_01', 'test01')
-            env.set('DUMMY_VAR_02', 'test02')
             config = Config.from_base_dir(project_dir)
             assert config['provisioning'][0]['inline'] == 'touch /opt/test01'
-            assert config['provisioning'][1]['inline'] == 'touch /opt/test02'
-            assert config['provisioning'][2]['inline'] == 'echo $thisisatest'
+            assert config['provisioning'][1]['inline'] == 'echo $thisisatest'
 
     def test_can_manage_config_with_interpolated_variables_coming_from_an_env_file(self):
         project_dir = os.path.join(FIXTURE_ROOT, 'project_with_dynamic_variables_and_env_file')
         config = Config.from_base_dir(project_dir)
         assert config['provisioning'][0]['inline'] == 'touch /opt/test01'
-        assert config['provisioning'][1]['inline'] == 'touch /opt/test02'
-        assert config['provisioning'][2]['inline'] == 'echo $thisisatest'
+        assert config['provisioning'][1]['inline'] == 'echo $thisisatest'
 
     def test_raises_an_error_if_a_variable_cannot_be_substituded(self):
         project_dir = os.path.join(FIXTURE_ROOT, 'project_with_dynamic_variables')


### PR DESCRIPTION
Only allow ${var} style variables but not $var anymore.

The latter causes issues with hashed password which then need to be escaped and that gets messy.

That also means that escaping of the $ character is no longer needed.