### PR TITLE
New: basic support for LXC profiles. Refs #68

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -193,6 +193,25 @@ Here is an example on how to set up a privileged container in your LXDock file:
 
   Please refer to :doc:`glossary`  for more details on these notions.
 
+profiles
+----------
+
+The ``profiles`` option defines the configuration profiles to use when creating containers. It should
+contain a list of profile names that exist in ``lxc profile list``. Please use ``lxc profile`` command
+to manage profiles as they are system-wide.
+
+.. code-block:: yaml
+
+  name: myproject
+  image: ubuntu/xenial
+  profiles:
+    - default
+    - docker
+
+  containers:
+    - name: test01
+    - name: test02
+
 protocol
 --------
 

--- a/docs/release_notes/v0.3.rst
+++ b/docs/release_notes/v0.3.rst
@@ -17,3 +17,5 @@ New features
   `#75 <https://github.com/lxdock/lxdock/pull/75>`_)
 * Add support for passing a command line with ``lxdock shell``
   (`#67 <https://github.com/lxdock/lxdock/pull/67>`_)
+* Add basic support for LXC profile in LXDock files
+  (`#77 <https://github.com/lxdock/lxdock/pull/77>`_)

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -12,6 +12,7 @@ _top_level_and_containers_common_options = {
     'lxc_config': {Extra: str},
     'mode': In(['local', 'pull', ]),
     'privileged': bool,
+    'profiles': [str, ],
     'protocol': In(['lxd', 'simplestreams', ]),
     'provisioning': [],  # will be set dynamically using provisioner classes...
     'server': Url(),

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -319,6 +319,10 @@ class Container:
             'config': lxc_config,
         }
 
+        profiles = self.options.get('profiles')
+        if profiles:
+            container_config['profiles'] = profiles.copy()
+
         try:
             return self.client.containers.create(container_config, wait=True)
         except LXDAPIException as e:


### PR DESCRIPTION
This pull request allows to set `profiles` in LXDock files, to use existing system-wide profiles.

In the future, LXDock may want to consider project-wise definition, etc.