### PR TITLE
Add option to disable setting host ACL on a share

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -269,8 +269,8 @@ of shared items. Each shared item should define a ``source`` (a path on your hos
 
 .. note::
 
-The ``set_host_acl`` parameter is optional and defaults to true when left out,
-please refer to :doc:`usage/shared_folders` for more information.
+  The ``set_host_acl`` parameter is optional and defaults to true when left out,
+  please refer to :doc:`usage/shared_folders` for more information.
 
 shell
 -----

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -265,6 +265,12 @@ of shared items. Each shared item should define a ``source`` (a path on your hos
   shares:
     - source: /path/to/my/workspace/project/
       dest: /myshare
+      set_host_acl: true
+
+.. note::
+
+The ``set_host_acl`` parameter is optional and defaults to true when left out,
+please refer to :doc:`usage/shared_folders` for more information.
 
 shell
 -----

--- a/docs/usage/shared_folders.rst
+++ b/docs/usage/shared_folders.rst
@@ -58,3 +58,31 @@ and will have read/write access to the shared folders:
     - name: test01
     - name: test02
       home: /opt/test02
+
+Disabling ACL support on shares
+-------------------------------
+
+By default ACLs will be turned on for all shares, however it is also possible to disable this
+functionality on a per-share basis.  One reason you might want to do this, is when you are
+using privileged containers and ensuring the container user matches the uid and gid
+of the host system.  This allows a share to be mapped without the use of ACLs, however the
+user should be aware of the security implications for making shares world-writable. This
+may be acceptable for development only containers for example.
+
+.. code-block:: yaml
+
+  name: myproject
+  image: ubuntu/xenial
+  privileged: yes
+
+  shares:
+    - source: .
+      dest: /myshare
+      set_host_acl: false
+
+  users:
+    - name: test01
+
+In this example, the Ansible provisioner can be used to change the uid and gid of
+the test01 user after it has been created by LXDock. How to implement this is
+up to the you, as LXDock does not provide a uid and gid option when creating users.

--- a/docs/usage/shared_folders.rst
+++ b/docs/usage/shared_folders.rst
@@ -85,4 +85,4 @@ may be acceptable for development only containers for example.
 
 In this example, the Ansible provisioner can be used to change the uid and gid of
 the test01 user after it has been created by LXDock. How to implement this is
-up to the you, as LXDock does not provide a uid and gid option when creating users.
+up to the user, as LXDock does not provide a uid and gid option when creating users.

--- a/docs/usage/shared_folders.rst
+++ b/docs/usage/shared_folders.rst
@@ -66,7 +66,7 @@ By default ACLs will be turned on for all shares, however it is also possible to
 functionality on a per-share basis.  One reason you might want to do this, is when you are
 using privileged containers and ensuring the container user matches the uid and gid
 of the host system.  This allows a share to be mapped without the use of ACLs, however the
-user should be aware of the security implications for making shares world-writable. This
+user should be aware of the security implications of making shares world-writable. This
 may be acceptable for development only containers for example.
 
 .. code-block:: yaml

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -20,6 +20,7 @@ _top_level_and_containers_common_options = {
         # The existence of the source directory will be checked!
         'source': IsDir(),
         'dest': str,
+        'set_host_acl': bool,
     }],
     'shell': {
         'user': str,

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -394,7 +394,9 @@ class Container:
 
         for i, share in enumerate(self.options.get('shares', []), start=1):
             source = os.path.join(self.homedir, share['source'])
-            if source not in existing_sources:
+            # It is possible to disable setting host side ACL but by default it is always enabled.
+            set_host_acl = share.get('set_host_acl', True)
+            if set_host_acl and source not in existing_sources:
                 logger.info('Setting host-side ACL for {}'.format(source))
                 self._host.give_current_user_access_to_share(source)
                 if not self.is_privileged:


### PR DESCRIPTION
This option defaults to True if not set so the existing behaviour stays the same.

Note: this replaces older PR #74 which can now be closed.

Not sure if a test is needed for this, as it changes very little
