### PR TITLE
Added support for provisioning-specific arguments to the up command

### DIFF
--- a/docs/cli/up.rst
+++ b/docs/cli/up.rst
@@ -1,7 +1,7 @@
 lxdock up
 =========
 
-**Command:** ``lxdock up [name [name ...]]``
+**Command:** ``lxdock up [name [name ...]] [arguments]``
 
 This command can be used to start the containers of your project.
 
@@ -13,12 +13,16 @@ Options
 -------
 
 * ``[name [name ...]]`` - zero, one or more container names
+* ``--provision`` - this option allows to force containers to be provisioned
+* ``--no-provision`` - this option allows to disable container provisioning
 
 Examples
 --------
 
 .. code-block:: console
 
-  $ lxdock up               # starts the containers of the project
-  $ lxdock up mycontainer   # starts the "mycontainer" container
-  $ lxdock up web ci        # starts the "web" and "ci" containers
+  $ lxdock up                 # starts the containers of the project
+  $ lxdock up mycontainer     # starts the "mycontainer" container
+  $ lxdock up web ci          # starts the "web" and "ci" containers
+  $ lxdock up --provision     # starts the containers of the project and provision them (even if they were already created)
+  $ lxdock up --no-provision  # starts the containers of the project but disable the provisioning step

--- a/lxdock/cli/main.py
+++ b/lxdock/cli/main.py
@@ -4,6 +4,7 @@ import sys
 
 from .. import __version__
 from ..conf.exceptions import ConfigError
+from ..constants import ProvisioningMode
 from ..exceptions import LXDockException
 from ..logging import console_stderr_handler, console_stdout_handler
 from .exceptions import CLIError
@@ -97,6 +98,14 @@ class LXDock:
             description='Create, start and provision all the containers of the project according '
                         'to your LXDock file. If container names are specified, only the related '
                         'containers are created, started and provisioned.')
+        up_provision_group = self._parsers['up'].add_mutually_exclusive_group()
+        up_provision_group.add_argument(
+            '--provision', action='store_const', const=ProvisioningMode.ENABLED,
+            dest='provisioning_mode', help='Enable and force provisioning.')
+        up_provision_group.add_argument(
+            '--no-provision', action='store_const', const=ProvisioningMode.DISABLED,
+            dest='provisioning_mode', help='Disable provisioning.')
+        up_provision_group.set_defaults(provisioning_mode=None)
 
         # Add common arguments to the action parsers that can be used with one or more specific
         # containers.
@@ -213,7 +222,7 @@ class LXDock:
         self.project.status(container_names=args.name)
 
     def up(self, args):
-        self.project.up(container_names=args.name)
+        self.project.up(container_names=args.name, provisioning_mode=args.provisioning_mode)
 
     ##################################
     # UTILITY METHODS AND PROPERTIES #

--- a/lxdock/constants.py
+++ b/lxdock/constants.py
@@ -1,5 +1,33 @@
-# CONTAINERS
+"""
+    The ``constants`` module
+    ========================
+
+    This module defines top-level constants that can be used all tools or classes provided by
+    LXDock, such as projects, containers or CLI parsers.
+
+"""
+
+from enum import Enum
+
+
+# CONTAINER STATUSES
 # --
 
 CONTAINER_STOPPED = 102
 CONTAINER_RUNNING = 103
+
+
+# PROVISIONING
+# --
+
+class ProvisioningMode(Enum):
+    """ Defines some common values that can be used to identify provisioning behavior types. """
+
+    # In "auto" mode containers will be provisioned only at creation time.
+    AUTO = 1
+
+    # In "enabled" mode containers will be systematically provisioned.
+    ENABLED = 2
+
+    # In "disabled" mode containers won't be provisioned.
+    DISABLED = 3

--- a/lxdock/project.py
+++ b/lxdock/project.py
@@ -76,13 +76,13 @@ class Project:
             logger.info('{container_name} ({status})'.format(
                 container_name=container.name.ljust(max_name_length + 10), status=container.status))
 
-    def up(self, container_names=None):
+    def up(self, container_names=None, **kwargs):
         """ Creates, starts and provisions the containers of the project. """
         containers = [self.get_container_by_name(name) for name in container_names] \
             if container_names else self.containers
         [logger.info('Bringing container "{}" up'.format(c.name)) for c in containers]
         for container in self._containers_generator(containers=containers):
-            container.up()
+            container.up(**kwargs)
         self._update_guest_etchosts()
 
     ##################################

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -8,6 +8,7 @@ from lxdock.cli.main import LXDock, main
 from lxdock.cli.project import get_project
 from lxdock.conf.config import Config
 from lxdock.conf.exceptions import ConfigError
+from lxdock.constants import ProvisioningMode
 from lxdock.container import Container
 from lxdock.exceptions import LXDockException
 from lxdock.project import Project
@@ -236,7 +237,8 @@ class TestLXDock:
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
         LXDock(['up'])
         assert mock_project_up.call_count == 1
-        assert mock_project_up.call_args == [{'container_names': [], }, ]
+        assert mock_project_up.call_args == [
+            {'container_names': [], 'provisioning_mode': None, }, ]
 
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'up')
@@ -246,7 +248,30 @@ class TestLXDock:
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
         LXDock(['up', 'c1', 'c2'])
         assert mock_project_up.call_count == 1
-        assert mock_project_up.call_args == [{'container_names': ['c1', 'c2', ], }, ]
+        assert mock_project_up.call_args == [
+            {'container_names': ['c1', 'c2', ], 'provisioning_mode': None, }, ]
+
+    @unittest.mock.patch.object(LXDock, 'project')
+    @unittest.mock.patch.object(Project, 'up')
+    def test_can_run_the_up_action_with_provisioning_enabled(
+            self, mock_project_up, mock_project):
+        mock_project.__get__ = unittest.mock.Mock(
+            return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
+        LXDock(['up', '--provision', ])
+        assert mock_project_up.call_count == 1
+        assert mock_project_up.call_args == [
+            {'container_names': [], 'provisioning_mode': ProvisioningMode.ENABLED, }, ]
+
+    @unittest.mock.patch.object(LXDock, 'project')
+    @unittest.mock.patch.object(Project, 'up')
+    def test_can_run_the_up_action_with_provisioning_disabled(
+            self, mock_project_up, mock_project):
+        mock_project.__get__ = unittest.mock.Mock(
+            return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
+        LXDock(['up', '--no-provision', ])
+        assert mock_project_up.call_count == 1
+        assert mock_project_up.call_args == [
+            {'container_names': [], 'provisioning_mode': ProvisioningMode.DISABLED, }, ]
 
     def test_exit_if_no_action_is_provided(self):
         with pytest.raises(SystemExit):


### PR DESCRIPTION
This PR adds support for using the `up` command as follows:

    $ lxdock up --provision
    $ lxdock up --no-provision