### PR TITLE
Add documentation of experimental LXD(ock) setup on Fedora

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -39,6 +39,14 @@ For Debian and Ubuntu, the following command will ensure that LXD is installed:
     $ sudo apt-get update
     $ sudo apt-get install lxd
 
+For Fedora, LXD is available through an experimental COPR repository. Unfortunately SELinux is not
+yet supported, therefore make sure it is disabled or set to permissive. Then run:
+
+.. code-block:: console
+
+    # dnf copr enable ganto/lxd
+    # dnf install lxd lxd-tools
+
 You should now be able to configure your LXD installation using:
 
 .. code-block:: console


### PR DESCRIPTION
Since a while I'm maintaining a community build of the `lxd` package for Fedora on COPR ([ganto/lxd](https://copr.fedorainfracloud.org/coprs/ganto/lxd/)). Recently I found `lxdock` and since I was a frequent Vagrant/LXC user, I found some interest in LXDock too. Therefore I also started a COPR repository [ganto/lxdock](https://copr.fedorainfracloud.org/coprs/ganto/lxdock/).

Those repositories are maintained on a best effort basis. Feedback is always welcome. 

Are you interested in adding a hint to this to your documentation?