### PR TITLE
Add an inventory option to Ansible provisioner

### DIFF
--- a/docs/provisioners/ansible.rst
+++ b/docs/provisioners/ansible.rst
@@ -37,6 +37,19 @@ your containers are provisioned.
 Optional options
 ----------------
 
+inventory
+=========
+
+You can use this option to force the inventory file path. Here is an example:
+
+.. code-block:: yaml
+
+  [...]
+  provisioning:
+    - type: ansible
+      playbook: deploy/site.yml
+      inventory: inventories/dev
+
 ask_vault_pass
 ==============
 

--- a/lxdock/provisioners/ansible.py
+++ b/lxdock/provisioners/ansible.py
@@ -27,12 +27,18 @@ class AnsibleProvisioner(Provisioner):
 
     schema = {
         Required('playbook'): IsFile(),
+        'inventory': str,
         'ask_vault_pass': bool,
         'vault_password_file': IsFile(),
     }
 
     def provision(self):
         """ Performs the provisioning operations using ansible-playbook. """
+        inventory = self.options.get('inventory')
+        if inventory is not None:
+            self.host.run(self._build_ansible_playbook_command_args(inventory))
+            return
+
         ip = get_ip(self.guest.lxd_container)
         with tempfile.NamedTemporaryFile() as tmpinv:
             tmpinv.write('{} ansible_user=root'.format(ip).encode('ascii'))

--- a/tests/unit/provisioners/test_ansible.py
+++ b/tests/unit/provisioners/test_ansible.py
@@ -22,6 +22,20 @@ class TestAnsibleProvisioner:
             './deploy.yml', mock_popen.call_args[0][0])
 
     @unittest.mock.patch('subprocess.Popen')
+    def test_can_run_ansible_playbooks_with_the_inventory_option(self, mock_popen):
+        host = Host(unittest.mock.Mock())
+        guest = DebianGuest(unittest.mock.Mock())
+        lxd_state = unittest.mock.Mock()
+        lxd_state.network.__getitem__ = unittest.mock.MagicMock(
+            return_value={'addresses': [{'family': 'init', 'address': '0.0.0.0', }, ]})
+        guest.lxd_container.state.return_value = lxd_state
+        provisioner = AnsibleProvisioner(
+            './', host, guest, {'playbook': 'deploy.yml', 'inventory': 'path/to/inventory'})
+        provisioner.provision()
+        assert 'ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook ' \
+            '--inventory-file path/to/inventory ./deploy.yml' == mock_popen.call_args[0][0]
+
+    @unittest.mock.patch('subprocess.Popen')
     def test_can_run_ansible_playbooks_with_the_vault_password_file_option(self, mock_popen):
         host = Host(unittest.mock.Mock())
         guest = DebianGuest(unittest.mock.Mock())


### PR DESCRIPTION
This PR implements the "inventory" option for Ansible provisioner as suggested in #88.