### PR TITLE
Add global provisioning capabilities

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -239,6 +239,16 @@ can be an Ansible playbook to run:
     - type: ansible
       playbook: deploy/site.yml
 
+
+Unlike normal configuration options, whether it is declared globally or specifically to a container
+has a special meaning for some provisioners. For example, a global ``ansible`` provisioner will
+only run **once** with an inventory including all containers. For some other provisioner, the global
+context doesn't make sense, so in these cases, these provisioner will be ran individually on each
+container.
+
+Like with other configuration options, however, you can of course declare a ``provisioning`` section
+locally to target a specific container.
+
 .. note::
 
   Please refer to :doc:`provisioners/index` to see the full list of supported provisioners.

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -85,43 +85,27 @@ class Container:
             self._container.stop(force=True, wait=True)
 
     @must_be_created_and_running
-    def provision(self):
+    def provision(self, force=True):
         """ Provisions the container. """
         # We run this in case our lxdock.yml config was modified since our last `lxdock up`.
         self._setup_env()
-        barebone = not self.is_provisioned
 
-        provisioning_steps = self.options.get('provisioning', [])
+        try:
+            provisioning_steps = self.options['provisioning']
+        except KeyError:
+            return
 
-        if barebone:
-            self._perform_barebones_setup()
+        if not force and self._guest.is_provisioned():
+            return
 
-        # Instantiate all provisioners
-        provisioners = []
         for provisioning_item in provisioning_steps:
             provisioning_type = provisioning_item['type'].lower()
             provisioner_class = Provisioner.provisioners.get(provisioning_type)
             if provisioner_class is not None:
                 provisioner = provisioner_class(
-                    self.homedir, self._host, self._guest, provisioning_item)
-                provisioners.append(provisioner)
-
-        logger.info('Provisioning container "{name}"...'.format(name=self.name))
-
-        # Do barebone setups for each provisioner if necessary
-        if barebone:
-            for provisioner in provisioners:
-                logger.info('Performing barebones setup for provisioner {0}'.format(
-                    provisioner.name))
-                provisioner.setup()
-
-        # Provision
-        for provisioner in provisioners:
-            logger.info('Provisioning with {0}'.format(provisioner.name))
-            provisioner.provision()
-
-        self._container.config['user.lxdock.provisioned'] = 'true'
-        self._container.save(wait=True)
+                    self.homedir, self._host, [self._guest], provisioning_item)
+                logger.info('Provisioning with {0}'.format(provisioner.name))
+                provisioner.provision()
 
     @must_be_created_and_running
     def shell(self, username=None, cmd_args=[]):
@@ -162,7 +146,7 @@ class Container:
 
         subprocess.call(cmd, shell=True)
 
-    def up(self, provisioning_mode=None):
+    def up(self):
         """ Creates, starts and provisions the container. """
         if self.is_running:
             logger.info('Container "{name}" is already running'.format(name=self.name))
@@ -192,18 +176,6 @@ class Container:
         # Override environment variables
         self._setup_env()
 
-        # Provisions the container if applicable; that is only if it hasn't been provisioned before
-        # or if the provisioning is manually enabled.
-        is_provisioned = self.is_provisioned
-        provisioning_mode = provisioning_mode or constants.ProvisioningMode.AUTO
-        if not provisioning_mode == constants.ProvisioningMode.DISABLED:
-            if (not is_provisioned and provisioning_mode == constants.ProvisioningMode.AUTO) or \
-                    provisioning_mode == constants.ProvisioningMode.ENABLED:
-                self.provision()
-            elif is_provisioned:
-                logger.info('Container "{name}" already provisioned, '
-                            'not provisioning.'.format(name=self.name))
-
     ##################################
     # UTILITY METHODS AND PROPERTIES #
     ##################################
@@ -222,11 +194,6 @@ class Container:
     def is_privileged(self):
         """ Returns a boolean indicating if the container is privileged. """
         return self._container.config.get('security.privileged') == 'true'
-
-    @property
-    def is_provisioned(self):
-        """ Returns a boolean indicating if the container is provisioned. """
-        return self._container.config.get('user.lxdock.provisioned') == 'true'
 
     @property
     def is_running(self):
@@ -344,17 +311,6 @@ class Container:
             logger.error("Can't create container: {error}".format(error=e))
             raise ContainerOperationFailed()
 
-    def _perform_barebones_setup(self):
-        """ Performs bare bones setup on the machine. """
-        logger.info('Doing bare bones setup on the machine...')
-
-        # Add the current user's SSH pubkey to the container's root SSH config.
-        ssh_pubkey = self._host.get_ssh_pubkey()
-        if ssh_pubkey is not None:
-            self._guest.add_ssh_pubkey_to_root_authorized_keys(ssh_pubkey)
-        else:
-            logger.warning('SSH pubkey was not found. Provisioning tools may not work correctly...')
-
     def _setup_env(self):
         """ Add environment overrides from the conf to our container config. """
         env_override = self.options.get('environment')
@@ -417,12 +373,13 @@ class Container:
                 if not self.is_privileged:
                     # We are considering a safe container. So give the mapped root user permissions
                     # to read/write contents in the shared folders too.
-                    self._host.give_mapped_user_access_to_share(source)
+                    self._host.give_mapped_user_access_to_share(self._container, source)
                     # We also give these permissions to any user that was created with LXDock.
                     for uconfig in self.options.get('users', []):
                         username = uconfig.get('name')
                         self._host.give_mapped_user_access_to_share(
-                            source, userpath=uconfig.get('home', '/home/' + username))
+                            self._container, source,
+                            userpath=uconfig.get('home', '/home/' + username))
 
             shareconf = {'type': 'disk', 'source': source, 'path': share['dest'], }
             container.devices['lxdockshare%s' % i] = shareconf
@@ -472,20 +429,14 @@ class Container:
 
     @property
     def _guest(self):
-        """ Returns the `Guest` instance associated with the considered container.
-
-        None is returned if no guest class can be determined for the considered container. """
+        """ Returns the `Guest` instance associated with the considered container. """
         if not hasattr(self, '_container_guest'):
-            guest_class = next((k for k in Guest.guests if k.detect(self._container)), Guest)
-            self._container_guest = guest_class(self._container)
+            self._container_guest = Guest.get(self)
         return self._container_guest
 
     @property
     def _host(self):
-        """ Returns the `Host` instance associated with the considered host.
-
-        None is returned if no guest class can be determined for the considered container. """
+        """ Returns the `Host` instance associated with the considered host. """
         if not hasattr(self, '_container_host'):
-            host_class = next((k for k in Host.hosts if k.detect()), Host)
-            self._container_host = host_class(self._container)
+            self._container_host = Host.get()
         return self._container_host

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -95,7 +95,7 @@ class Container:
         except KeyError:
             return
 
-        if not force and self._guest.is_provisioned():
+        if not force and self.is_provisioned:
             return
 
         for provisioning_item in provisioning_steps:
@@ -194,6 +194,11 @@ class Container:
     def is_privileged(self):
         """ Returns a boolean indicating if the container is privileged. """
         return self._container.config.get('security.privileged') == 'true'
+
+    @property
+    def is_provisioned(self):
+        """ Returns a boolean indicating if the container is provisioned. """
+        return self._container.config.get('user.lxdock.provisioned') == 'true'
 
     @property
     def is_running(self):

--- a/lxdock/guests/base.py
+++ b/lxdock/guests/base.py
@@ -182,10 +182,6 @@ class Guest(with_metaclass(_GuestBase)):
         self.run(['tar', '-xf', guest_tar_path, '-C', str(guest_path)])
         self.run(['rm', '-f', str(guest_tar_path)])
 
-    def is_provisioned(self):
-        """ Returns a boolean indicating if the container is provisioned. """
-        return self.lxd_container.config.get('user.lxdock.provisioned') == 'true'
-
     ##################################
     # PRIVATE METHODS AND PROPERTIES #
     ##################################

--- a/lxdock/guests/base.py
+++ b/lxdock/guests/base.py
@@ -76,8 +76,9 @@ class Guest(with_metaclass(_GuestBase)):
     # The `name` of a guest is a required attribute and should always be set on `Guest` subclasses.
     name = None
 
-    def __init__(self, lxd_container):
-        self.lxd_container = lxd_container
+    def __init__(self, container):
+        self.container = container
+        self.lxd_container = container._container
 
     @classmethod
     def detect(cls, lxd_container):
@@ -103,6 +104,12 @@ class Guest(with_metaclass(_GuestBase)):
             if found:
                 break
         return found
+
+    @classmethod
+    def get(cls, container):
+        """ Returns the `Guest` instance associated with the considered container. """
+        class_ = next((k for k in cls.guests if k.detect(container._container)), Guest)
+        return class_(container)
 
     def add_ssh_pubkey_to_root_authorized_keys(self, pubkey):
         """ Add a given SSH public key to the root user's authorized keys. """
@@ -174,6 +181,10 @@ class Guest(with_metaclass(_GuestBase)):
             self.copy_file(Path(f.name), PurePosixPath(guest_tar_path))
         self.run(['tar', '-xf', guest_tar_path, '-C', str(guest_path)])
         self.run(['rm', '-f', str(guest_tar_path)])
+
+    def is_provisioned(self):
+        """ Returns a boolean indicating if the container is provisioned. """
+        return self.lxd_container.config.get('user.lxdock.provisioned') == 'true'
 
     ##################################
     # PRIVATE METHODS AND PROPERTIES #

--- a/lxdock/project.py
+++ b/lxdock/project.py
@@ -3,9 +3,12 @@ import logging
 from . import constants
 from .container import Container
 from .exceptions import ProjectError
+from .guests import Guest
+from .hosts import Host
 from .logging import (console_stderr_handler, console_stdout_handler, get_default_formatter,
                       get_per_container_formatter)
 from .network import ContainerEtcHosts, EtcHosts
+from .provisioners import Provisioner
 
 
 logger = logging.getLogger(__name__)
@@ -14,11 +17,12 @@ logger = logging.getLogger(__name__)
 class Project:
     """ A project is used to orchestrate a collection of containers. """
 
-    def __init__(self, name, homedir, client, containers):
+    def __init__(self, name, homedir, client, containers, provisioning_steps):
         self.name = name
         self.homedir = homedir
         self.client = client
         self.containers = containers
+        self.provisioning_steps = provisioning_steps
 
     @classmethod
     def from_config(cls, project_name, client, config):
@@ -26,7 +30,7 @@ class Project:
         containers = []
         for container_config in config.containers:
             containers.append(Container(project_name, config.homedir, client, **container_config))
-        return cls(project_name, config.homedir, client, containers)
+        return cls(project_name, config.homedir, client, containers, config.provisioning_steps)
 
     #####################
     # CONTAINER ACTIONS #
@@ -48,12 +52,36 @@ class Project:
             container.halt()
         self._update_guest_etchosts()
 
-    def provision(self, container_names=None):
+    def provision(self, container_names=None, force=True):
         """ Provisions the containers of the project. """
+        # This happens in two phases: local provisioning, then global provisioning.
+        # Local provisioning is the provisioning that is declared directly in the
+        # `containers` config section. Global provisioning is declared at the root
+        # of the config.
         containers = [self.get_container_by_name(name) for name in container_names] \
             if container_names else self.containers
         for container in self._containers_generator(containers=containers):
-            container.provision()
+            container.provision(force=force)
+
+        host = Host.get()
+        guests = [Guest.get(c) for c in containers]
+        if not force:
+            guests = [g for g in guests if not g.is_provisioned()]
+        if not guests:
+            return
+
+        for provisioning_item in self.provisioning_steps:
+            provisioning_type = provisioning_item['type'].lower()
+            provisioner_class = Provisioner.provisioners.get(provisioning_type)
+            if provisioner_class is not None:
+                provisioner = provisioner_class(
+                    self.homedir, host, guests, provisioning_item)
+                logger.info('Global provisioning with {0}'.format(provisioner.name))
+                provisioner.provision()
+
+        for guest in guests:
+            guest.lxd_container.config['user.lxdock.provisioned'] = 'true'
+            guest.lxd_container.save(wait=True)
 
     def shell(self, container_name=None, **kwargs):
         """ Opens a new shell in our first container. """
@@ -76,14 +104,25 @@ class Project:
             logger.info('{container_name} ({status})'.format(
                 container_name=container.name.ljust(max_name_length + 10), status=container.status))
 
-    def up(self, container_names=None, **kwargs):
+    def up(self, container_names=None, provisioning_mode=None):
         """ Creates, starts and provisions the containers of the project. """
         containers = [self.get_container_by_name(name) for name in container_names] \
             if container_names else self.containers
-        [logger.info('Bringing container "{}" up'.format(c.name)) for c in containers]
-        for container in self._containers_generator(containers=containers):
-            container.up(**kwargs)
+        not_running = [c for c in containers if not c.is_running]
+        if not not_running:
+            logger.warning("Everything is already up and running! Nothing to do.")
+            return
+        [logger.info('Bringing container "{}" up'.format(c.name)) for c in not_running]
+        for container in self._containers_generator(containers=not_running):
+            container.up()
         self._update_guest_etchosts()
+
+        # Provisions the container if applicable; that is only if it hasn't been provisioned before
+        # or if the provisioning is manually enabled.
+        provisioning_mode = provisioning_mode or constants.ProvisioningMode.AUTO
+        if not provisioning_mode == constants.ProvisioningMode.DISABLED:
+            force = provisioning_mode == constants.ProvisioningMode.ENABLED
+            self.provision(container_names=[c.name for c in not_running], force=force)
 
     ##################################
     # UTILITY METHODS AND PROPERTIES #

--- a/lxdock/project.py
+++ b/lxdock/project.py
@@ -64,12 +64,12 @@ class Project:
             container.provision(force=force)
 
         host = Host.get()
-        guests = [Guest.get(c) for c in containers]
         if not force:
-            guests = [g for g in guests if not g.is_provisioned()]
-        if not guests:
+            containers = [c for c in containers if not c.is_provisioned]
+        if not containers:
             return
 
+        guests = [Guest.get(c) for c in containers]
         for provisioning_item in self.provisioning_steps:
             provisioning_type = provisioning_item['type'].lower()
             provisioner_class = Provisioner.provisioners.get(provisioning_type)

--- a/lxdock/provisioners/ansible.py
+++ b/lxdock/provisioners/ansible.py
@@ -31,37 +31,54 @@ class AnsibleProvisioner(Provisioner):
         'vault_password_file': IsFile(),
     }
 
+    def get_inventory(self, guests):
+        def line(guest):
+            ip = get_ip(guest.lxd_container)
+            return '{} ansible_user=root'.format(ip)
+
+        return '\n'.join(line(guest) for guest in guests)
+
     def provision(self):
         """ Performs the provisioning operations using ansible-playbook. """
-        ip = get_ip(self.guest.lxd_container)
+        self.setup()
         with tempfile.NamedTemporaryFile() as tmpinv:
-            tmpinv.write('{} ansible_user=root'.format(ip).encode('ascii'))
+            tmpinv.write(self.get_inventory(self.guests).encode('ascii'))
             tmpinv.flush()
             self.host.run(self._build_ansible_playbook_command_args(tmpinv.name))
 
-    def setup_guest_alpine(self):
+    def setup_single(self, guest):
+        super().setup_single(guest)
+
+        # Add the current user's SSH pubkey to the container's root SSH config.
+        ssh_pubkey = self.host.get_ssh_pubkey()
+        if ssh_pubkey is not None:
+            guest.add_ssh_pubkey_to_root_authorized_keys(ssh_pubkey)
+        else:
+            logger.warning('SSH pubkey was not found. Provisioning tools may not work correctly...')
+
+    def setup_guest_alpine(self, guest):
         # On alpine guests we have to ensure that ssd is started!
-        self.guest.run(['rc-update', 'add', 'sshd'])
-        self.guest.run(['/etc/init.d/sshd', 'start'])
+        guest.run(['rc-update', 'add', 'sshd'])
+        guest.run(['/etc/init.d/sshd', 'start'])
 
-    def setup_guest_arch(self):
+    def setup_guest_arch(self, guest):
         # On archlinux guests we have to ensure that sshd is started!
-        self.guest.run(['systemctl', 'enable', 'sshd'])
-        self.guest.run(['systemctl', 'start', 'sshd'])
+        guest.run(['systemctl', 'enable', 'sshd'])
+        guest.run(['systemctl', 'start', 'sshd'])
 
-    def setup_guest_centos(self):
+    def setup_guest_centos(self, guest):
         # On centos guests we have to ensure that sshd is started!
-        self.guest.run(['systemctl', 'enable', 'sshd'])
-        self.guest.run(['systemctl', 'start', 'sshd'])
+        guest.run(['systemctl', 'enable', 'sshd'])
+        guest.run(['systemctl', 'start', 'sshd'])
 
-    def setup_guest_fedora(self):
+    def setup_guest_fedora(self, guest):
         # On fedora guests we have to ensure that sshd is started!
-        self.guest.run(['systemctl', 'enable', 'sshd'])
-        self.guest.run(['systemctl', 'start', 'sshd'])
+        guest.run(['systemctl', 'enable', 'sshd'])
+        guest.run(['systemctl', 'start', 'sshd'])
 
-    def setup_guest_ol(self):
+    def setup_guest_ol(self, guest):
         # On oracle linux guests we have to ensure that sshd is started!
-        self.guest.run(['/sbin/service', 'sshd', 'start'])
+        guest.run(['/sbin/service', 'sshd', 'start'])
 
     ##################################
     # PRIVATE METHODS AND PROPERTIES #

--- a/lxdock/provisioners/base.py
+++ b/lxdock/provisioners/base.py
@@ -90,34 +90,50 @@ class Provisioner(with_metaclass(_ProvisionerBase)):
     #
     # These packages will be installed during the "provision" operation.
 
-    def __init__(self, homedir, host, guest, options):
+    def __init__(self, homedir, host, guests, options):
         self.homedir = homedir
         self.host = host
-        self.guest = guest
+        self.guests = guests
         self.options = options.copy()
 
     def provision(self):
         """ Performs the provisioning operations using the considered provisioner. """
-        # This method should be overriden in `Provisioner` subclasses.
+        # This method should be overriden in `Provisioner` subclasses that implement global
+        # provisioning.
+        self.setup()
+        for guest in self.guests:
+            self.provision_single(guest)
+
+    def provision_single(self, guest):
+        """ Performs the provisioning operations on the specified guest. """
+        # This method should be overriden in `Provisioner` subclasses that don't implement
+        # global provisioning.
 
     def setup(self):
-        """ Setups the provisioner if applicable. """
+        for guest in self.guests:
+            if not guest.is_provisioned():
+                self.setup_single(guest)
+
+    def setup_single(self, guest):
+        """ Setups the guest to run the provisioner if applicable. """
         # Ensure that the packages required to properly use the considered provisioner are installed
         # on the guest.
+        logger.info('Preparing {0} up for provisioner {1}'.format(
+            guest.container.name, self.name))
         required_packages = getattr(
-            self, 'guest_required_packages_{}'.format(self.guest.name), None)
+            self, 'guest_required_packages_{}'.format(guest.name), None)
         if required_packages is not None:
             logger.info(
                 'Installing packages required for the {} provisioner '
                 'on the guest'.format(self.name))
-            self.guest.install_packages(required_packages)
+            guest.install_packages(required_packages)
 
         # We allow `Provisioner` subclasses to define their own "setup_guest_{guestname}" methods
         # if setup operations have to be done on some specific guest prior to any provisioning
         # actions.
-        guest_setup_method = getattr(self, 'setup_guest_{}'.format(self.guest.name), None)
+        guest_setup_method = getattr(self, 'setup_guest_{}'.format(guest.name), None)
         if guest_setup_method is not None:
-            guest_setup_method()
+            guest_setup_method(guest)
 
     ##################
     # HELPER METHODS #

--- a/lxdock/provisioners/base.py
+++ b/lxdock/provisioners/base.py
@@ -111,7 +111,7 @@ class Provisioner(with_metaclass(_ProvisionerBase)):
 
     def setup(self):
         for guest in self.guests:
-            if not guest.is_provisioned():
+            if not guest.container.is_provisioned:
                 self.setup_single(guest)
 
     def setup_single(self, guest):

--- a/lxdock/provisioners/puppet.py
+++ b/lxdock/provisioners/puppet.py
@@ -81,19 +81,19 @@ class PuppetProvisioner(Provisioner):
     _guest_environment_path = '/.lxdock.d/puppet/environments'
     _guest_hiera_file = '/.lxdock.d/puppet/hiera.yaml'
 
-    def provision(self):
+    def provision_single(self, guest):
         """ Performs the provisioning operations using puppet. """
         # Verify if `puppet` has been installed.
         binary_path = self.options.get('binary_path')
         if binary_path is not None:
             puppet_bin = str(PurePosixPath(binary_path) / 'puppet')
-            retcode = self.guest.run(['test', '-x', puppet_bin])
+            retcode = guest.run(['test', '-x', puppet_bin])
             fail_msg = (
                 "puppet executable is not found in the specified path {} in the "
                 "guest container. ".format(binary_path)
             )
         else:
-            retcode = self.guest.run(['which', 'puppet'])
+            retcode = guest.run(['which', 'puppet'])
             fail_msg = (
                 "puppet was not automatically installed for this guest. "
                 "Please specify the command to install it in LXDock file using "
@@ -106,24 +106,24 @@ class PuppetProvisioner(Provisioner):
         # Copy manifests dir
         manifests_path = self.options.get('manifests_path')
         if manifests_path is not None:
-            self.guest.copy_directory(
+            guest.copy_directory(
                 Path(manifests_path), PurePosixPath(self._guest_manifests_path))
 
         # Copy module dir
         module_path = self.options.get('module_path')
         if module_path is not None:
-            self.guest.copy_directory(Path(module_path), PurePosixPath(self._guest_module_path))
+            guest.copy_directory(Path(module_path), PurePosixPath(self._guest_module_path))
 
         # Copy environment dir
         environment_path = self.options.get('environment_path')
         if environment_path is not None:
-            self.guest.copy_directory(
+            guest.copy_directory(
                 Path(environment_path), PurePosixPath(self._guest_environment_path))
 
         # Copy hiera file
         hiera_file = self.options.get('hiera_config_path')
         if hiera_file is not None:
-            self.guest.copy_file(Path(hiera_file), PurePosixPath(self._guest_hiera_file))
+            guest.copy_file(Path(hiera_file), PurePosixPath(self._guest_hiera_file))
 
         # Run puppet.
         command = self._build_puppet_command()
@@ -133,7 +133,7 @@ class PuppetProvisioner(Provisioner):
         else:
             logger.info("Running Puppet with {}...".format(self.options['manifest_file']))
 
-        self.guest.run(['sh', '-c', ' '.join(command)])
+        guest.run(['sh', '-c', ' '.join(command)])
 
     ##################################
     # PRIVATE METHODS AND PROPERTIES #

--- a/lxdock/test/__init__.py
+++ b/lxdock/test/__init__.py
@@ -5,5 +5,6 @@
     or run tests.
 """
 
+from .fakes import *  # noqa
 from .fixtures import *  # noqa
 from .testcases import *  # noqa

--- a/lxdock/test/fakes.py
+++ b/lxdock/test/fakes.py
@@ -1,0 +1,16 @@
+from unittest.mock import Mock
+
+from ..container import Container
+
+
+class FakeContainer(Container):
+    def __init__(self, project_name='project', homedir='/foo', client=None, **options):
+        if client is None:
+            client = Mock()
+        options.setdefault('name', 'fakecontainer')
+        super().__init__(project_name, homedir, client, **options)
+
+    def _get_container(self, create=True):
+        result = Mock()
+        result.execute.return_value = ('ok', 'ok', '')
+        return result

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,12 +4,7 @@ ipython>=5.1.0
 ansible>=2.1
 
 # Testing
-codecov>=1.6
-pytest>=3.0
-pytest-cov>=1.8
-pytest-spec>=0.2
-pytest-sugar>=0.7.0
-tox>=1.7
+-r requirements-tests.txt
 
 # Lint / isort
 isort>=4.2

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,6 @@
+codecov>=1.6
+pytest>=3.0
+pytest-cov>=1.8
+pytest-spec>=0.2
+pytest-sugar>=0.7.0
+tox>=1.7

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -83,7 +83,7 @@ class TestContainer(LXDTestCase):
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.up()
-        assert container._container.config['user.lxdock.provisioned'] == 'true'
+        container.provision()
         assert container._container.files.get('/dummytest').strip() == b'dummytest'
 
     def test_can_provision_a_container_shell_inline(self):
@@ -97,7 +97,7 @@ class TestContainer(LXDTestCase):
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.up()
-        assert container._container.config['user.lxdock.provisioned'] == 'true'
+        container.provision()
         assert container._container.files.get('/tmp/test.txt').strip() == (
             b"Here's the PATH /dummy_test:/bin:/usr/bin:/usr/local/bin")
 
@@ -175,13 +175,6 @@ class TestContainer(LXDTestCase):
         persistent_container._container.config['security.privileged'] = 'false'
         persistent_container._container.save(wait=True)
         assert not persistent_container.is_privileged
-
-    def test_can_tell_if_a_container_is_provisioned_or_not(self, persistent_container):
-        persistent_container._container.config['user.lxdock.provisioned'] = 'false'
-        persistent_container._container.save(wait=True)
-        assert not persistent_container.is_provisioned
-        persistent_container.provision()
-        assert persistent_container.is_provisioned
 
     def test_can_tell_if_a_container_is_running_or_not(self, persistent_container):
         persistent_container.halt()

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -176,6 +176,14 @@ class TestContainer(LXDTestCase):
         persistent_container._container.save(wait=True)
         assert not persistent_container.is_privileged
 
+    def test_can_tell_if_a_container_is_provisioned_or_not(self, persistent_container):
+        persistent_container._container.config['user.lxdock.provisioned'] = 'false'
+        persistent_container._container.save(wait=True)
+        assert not persistent_container.is_provisioned
+        persistent_container._container.config['user.lxdock.provisioned'] = 'true'
+        persistent_container._container.save(wait=True)
+        assert persistent_container.is_provisioned
+
     def test_can_tell_if_a_container_is_running_or_not(self, persistent_container):
         persistent_container.halt()
         assert not persistent_container.is_running

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -3,6 +3,7 @@ import unittest.mock
 
 import pytest
 
+from lxdock import constants
 from lxdock.conf.config import Config
 from lxdock.container import Container
 from lxdock.exceptions import ProjectError
@@ -84,18 +85,18 @@ class TestProject(LXDTestCase):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
         container_options = {
             'name': self.containername('dummytest'), 'image': 'ubuntu/xenial', 'mode': 'pull',
-            'provisioning': [
-                {'type': 'ansible',
-                 'playbook': os.path.join(THIS_DIR, 'fixtures/provision_with_ansible.yml'), }
-            ],
         }
+        provisioning_steps = [
+            {'type': 'ansible',
+             'playbook': os.path.join(THIS_DIR, 'fixtures/provision_with_ansible.yml'), }
+        ]
         project = Project(
             'project02', homedir, self.client,
-            [Container('myproject', THIS_DIR, self.client, **container_options)])
-        project.up()
-        project.provision()
+            [Container('myproject', THIS_DIR, self.client, **container_options)],
+            provisioning_steps=provisioning_steps)
+        project.up()  # implicit provisioning
         for container in project.containers:
-            assert container.is_provisioned
+            assert container._guest.is_provisioned
 
     def test_can_provision_some_specific_containers_of_a_project(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
@@ -108,24 +109,22 @@ class TestProject(LXDTestCase):
         }
         project = Project(
             'project02', homedir, self.client,
-            [Container('myproject', THIS_DIR, self.client, **container_options)])
-        project.up()
+            [Container('myproject', THIS_DIR, self.client, **container_options)],
+            provisioning_steps=[])
+        project.up(provisioning_mode=constants.ProvisioningMode.DISABLED)
         project.provision(container_names=['lxdock-pytest-thisisatest'])
         container_web = project.get_container_by_name('lxdock-pytest-thisisatest')
-        assert container_web.is_provisioned
+        assert container_web._guest.is_provisioned
 
     def test_can_destroy_all_the_containers_of_a_project(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
         container_options = {
-            'name': self.containername('dummytest'), 'image': 'ubuntu/xenial', 'mode': 'pull',
-            'provisioning': [
-                {'type': 'ansible',
-                 'playbook': os.path.join(THIS_DIR, 'fixtures/provision_with_ansible.yml'), }
-            ],
+            'name': self.containername('dummytest'), 'image': 'ubuntu/xenial',
         }
         project = Project(
             'project02', homedir, self.client,
-            [Container('myproject', THIS_DIR, self.client, **container_options)])
+            [Container('myproject', THIS_DIR, self.client, **container_options)],
+            provisioning_steps=[])
         project.up()
         project.destroy()
         for container in project.containers:
@@ -152,7 +151,7 @@ class TestProject(LXDTestCase):
     @unittest.mock.patch('subprocess.call')
     def test_can_open_a_shell_for_a_specific_container(self, mocked_call, persistent_container):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
-        project = Project('project02', homedir, self.client, [persistent_container, ])
+        project = Project('project02', homedir, self.client, [persistent_container, ], [])
         project.shell(container_name='testcase-persistent')
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
@@ -162,7 +161,7 @@ class TestProject(LXDTestCase):
     def test_can_run_shell_command_for_a_specific_container(
             self, mocked_call, persistent_container):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
-        project = Project('project02', homedir, self.client, [persistent_container, ])
+        project = Project('project02', homedir, self.client, [persistent_container, ], [])
         project.shell(container_name='testcase-persistent', cmd_args=['echo', 'HELLO'])
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
@@ -172,7 +171,7 @@ class TestProject(LXDTestCase):
     @unittest.mock.patch.object(project_logger, 'info')
     def test_can_return_the_statuses_of_containers(self, mock_info, persistent_container):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
-        project = Project('project02', homedir, self.client, [persistent_container, ])
+        project = Project('project02', homedir, self.client, [persistent_container, ], [])
         project.status(container_names=['testcase-persistent'])
         assert mock_info.call_count == 2
         assert mock_info.call_args[0][0] == 'testcase-persistent           (running)'

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -96,7 +96,7 @@ class TestProject(LXDTestCase):
             provisioning_steps=provisioning_steps)
         project.up()  # implicit provisioning
         for container in project.containers:
-            assert container._guest.is_provisioned
+            assert container.is_provisioned
 
     def test_can_provision_some_specific_containers_of_a_project(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
@@ -114,7 +114,7 @@ class TestProject(LXDTestCase):
         project.up(provisioning_mode=constants.ProvisioningMode.DISABLED)
         project.provision(container_names=['lxdock-pytest-thisisatest'])
         container_web = project.get_container_by_name('lxdock-pytest-thisisatest')
-        assert container_web._guest.is_provisioned
+        assert container_web.is_provisioned
 
     def test_can_destroy_all_the_containers_of_a_project(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')

--- a/tests/unit/guests/test_alpine.py
+++ b/tests/unit/guests/test_alpine.py
@@ -1,14 +1,12 @@
-import unittest.mock
-
 from lxdock.guests import AlpineGuest
+from lxdock.test import FakeContainer
 
 
 class TestAlpineGuest:
     def test_can_install_packages(self):
-        lxd_container = unittest.mock.Mock()
-        lxd_container.execute.return_value = ('ok', 'ok', '')
-        guest = AlpineGuest(lxd_container)
+        guest = AlpineGuest(FakeContainer())
         guest.install_packages(['python', 'openssh', ])
-        assert lxd_container.execute.call_count == 2
-        assert lxd_container.execute.call_args_list[0][0] == (['apk', 'update'], )
-        assert lxd_container.execute.call_args_list[1][0] == (['apk', 'add', 'python', 'openssh'], )
+        assert guest.lxd_container.execute.call_count == 2
+        assert guest.lxd_container.execute.call_args_list[0][0] == (['apk', 'update'], )
+        assert guest.lxd_container.execute.call_args_list[1][0] == \
+            (['apk', 'add', 'python', 'openssh'], )

--- a/tests/unit/guests/test_archlinux.py
+++ b/tests/unit/guests/test_archlinux.py
@@ -1,14 +1,11 @@
-import unittest.mock
-
 from lxdock.guests import ArchLinuxGuest
+from lxdock.test import FakeContainer
 
 
 class TestArchLinuxGuest:
     def test_can_install_packages(self):
-        lxd_container = unittest.mock.Mock()
-        lxd_container.execute.return_value = ('ok', 'ok', '')
-        guest = ArchLinuxGuest(lxd_container)
+        guest = ArchLinuxGuest(FakeContainer())
         guest.install_packages(['python', 'openssh', ])
-        assert lxd_container.execute.call_count == 1
-        assert lxd_container.execute.call_args[0] == \
+        assert guest.lxd_container.execute.call_count == 1
+        assert guest.lxd_container.execute.call_args[0] == \
             (['pacman', '-S', '--noconfirm', 'python', 'openssh'], )

--- a/tests/unit/guests/test_centos.py
+++ b/tests/unit/guests/test_centos.py
@@ -1,14 +1,11 @@
-import unittest.mock
-
 from lxdock.guests import CentosGuest
+from lxdock.test import FakeContainer
 
 
 class TestCentosGuest:
     def test_can_install_packages(self):
-        lxd_container = unittest.mock.Mock()
-        lxd_container.execute.return_value = ('ok', 'ok', '')
-        guest = CentosGuest(lxd_container)
+        guest = CentosGuest(FakeContainer())
         guest.install_packages(['python', 'openssh', ])
-        assert lxd_container.execute.call_count == 1
-        assert lxd_container.execute.call_args[0] == \
+        assert guest.lxd_container.execute.call_count == 1
+        assert guest.lxd_container.execute.call_args[0] == \
             (['yum', '-y', 'install', 'python', 'openssh', ], )

--- a/tests/unit/guests/test_debian.py
+++ b/tests/unit/guests/test_debian.py
@@ -1,16 +1,13 @@
-import unittest.mock
-
 from lxdock.guests import DebianGuest
+from lxdock.test import FakeContainer
 
 
 class TestDebianGuest:
     def test_can_install_packages(self):
-        lxd_container = unittest.mock.Mock()
-        lxd_container.execute.return_value = ('ok', 'ok', '')
-        guest = DebianGuest(lxd_container)
+        guest = DebianGuest(FakeContainer())
         guest.install_packages(['python', 'openssh', ])
-        assert lxd_container.execute.call_count == 2
-        assert lxd_container.execute.call_args_list[0][0] == \
+        assert guest.lxd_container.execute.call_count == 2
+        assert guest.lxd_container.execute.call_args_list[0][0] == \
             (['apt-get', 'update', ], )
-        assert lxd_container.execute.call_args_list[1][0] == \
+        assert guest.lxd_container.execute.call_args_list[1][0] == \
             (['apt-get', 'install', '-y', 'python', 'openssh', ], )

--- a/tests/unit/guests/test_fedora.py
+++ b/tests/unit/guests/test_fedora.py
@@ -1,14 +1,11 @@
-import unittest.mock
-
 from lxdock.guests import FedoraGuest
+from lxdock.test import FakeContainer
 
 
 class TestFedoraGuest:
     def test_can_install_packages(self):
-        lxd_container = unittest.mock.Mock()
-        lxd_container.execute.return_value = ('ok', 'ok', '')
-        guest = FedoraGuest(lxd_container)
+        guest = FedoraGuest(FakeContainer())
         guest.install_packages(['python', 'openssh', ])
-        assert lxd_container.execute.call_count == 1
-        assert lxd_container.execute.call_args[0] == \
+        assert guest.lxd_container.execute.call_count == 1
+        assert guest.lxd_container.execute.call_args[0] == \
             (['dnf', '-y', 'install', 'python', 'openssh', ], )

--- a/tests/unit/guests/test_gentoo.py
+++ b/tests/unit/guests/test_gentoo.py
@@ -1,30 +1,28 @@
-import unittest.mock
-
 from lxdock.guests import GentooGuest
+from lxdock.test import FakeContainer
 
 
 class TestGentooGuest:
     def test_should_install_packages_if_not_installed(self):
-        lxd_container = unittest.mock.Mock()
+        guest = GentooGuest(FakeContainer())
         # Retcode 1: "No installed packages matching {keyword}"
-        lxd_container.execute.return_value = (1, 'ok', '')
-        guest = GentooGuest(lxd_container)
+        guest.lxd_container.execute.return_value = (1, 'ok', '')
         guest.install_packages(['python', 'openssh', ])
-        assert lxd_container.execute.call_count == 5
-        assert lxd_container.execute.call_args_list[0][0] == \
+        assert guest.lxd_container.execute.call_count == 5
+        assert guest.lxd_container.execute.call_args_list[0][0] == \
             (['emerge', 'app-portage/gentoolkit'], )
         for i, p in enumerate(['python', 'openssh', ]):
-            assert lxd_container.execute.call_args_list[2 * i + 1][0] == (['equery', 'list', p], )
-            assert lxd_container.execute.call_args_list[2 * i + 2][0] == (['emerge', p], )
+            assert guest.lxd_container.execute.call_args_list[2 * i + 1][0] == \
+                (['equery', 'list', p], )
+            assert guest.lxd_container.execute.call_args_list[2 * i + 2][0] == (['emerge', p], )
 
     def test_should_not_reinstall_packages_if_already_installed(self):
-        lxd_container = unittest.mock.Mock()
+        guest = GentooGuest(FakeContainer())
         # Retcode 0: the package has been found locally
-        lxd_container.execute.return_value = (0, 'ok', '')
-        guest = GentooGuest(lxd_container)
+        guest.lxd_container.execute.return_value = (0, 'ok', '')
         guest.install_packages(['python', 'openssh', ])
-        assert lxd_container.execute.call_count == 3
-        assert lxd_container.execute.call_args_list[0][0] == \
+        assert guest.lxd_container.execute.call_count == 3
+        assert guest.lxd_container.execute.call_args_list[0][0] == \
             (['emerge', 'app-portage/gentoolkit'], )
         for i, p in enumerate(['python', 'openssh', ]):
-            assert lxd_container.execute.call_args_list[i + 1][0] == (['equery', 'list', p], )
+            assert guest.lxd_container.execute.call_args_list[i + 1][0] == (['equery', 'list', p], )

--- a/tests/unit/guests/test_opensuse.py
+++ b/tests/unit/guests/test_opensuse.py
@@ -1,14 +1,11 @@
-import unittest.mock
-
 from lxdock.guests import OpenSUSEGuest
+from lxdock.test import FakeContainer
 
 
 class TestOpenSUSEGuest:
     def test_can_install_packages(self):
-        lxd_container = unittest.mock.Mock()
-        lxd_container.execute.return_value = ('ok', 'ok', '')
-        guest = OpenSUSEGuest(lxd_container)
+        guest = OpenSUSEGuest(FakeContainer())
         guest.install_packages(['python', 'openssh', ])
-        assert lxd_container.execute.call_count == 1
-        assert lxd_container.execute.call_args[0] == \
+        assert guest.lxd_container.execute.call_count == 1
+        assert guest.lxd_container.execute.call_args[0] == \
             (['zypper', '--non-interactive', 'install', 'python', 'openssh', ], )

--- a/tests/unit/guests/test_oracle.py
+++ b/tests/unit/guests/test_oracle.py
@@ -1,14 +1,11 @@
-import unittest.mock
-
 from lxdock.guests import OracleLinuxGuest
+from lxdock.test import FakeContainer
 
 
 class TestOracleLinuxGuest:
     def test_can_install_packages(self):
-        lxd_container = unittest.mock.Mock()
-        lxd_container.execute.return_value = ('ok', 'ok', '')
-        guest = OracleLinuxGuest(lxd_container)
+        guest = OracleLinuxGuest(FakeContainer())
         guest.install_packages(['python', 'openssh', ])
-        assert lxd_container.execute.call_count == 1
-        assert lxd_container.execute.call_args[0] == \
+        assert guest.lxd_container.execute.call_count == 1
+        assert guest.lxd_container.execute.call_args[0] == \
             (['yum', '-y', 'install', 'python', 'openssh', ], )

--- a/tests/unit/hosts/test_base.py
+++ b/tests/unit/hosts/test_base.py
@@ -7,6 +7,7 @@ import pytest
 
 from lxdock.hosts import Host
 from lxdock.hosts.base import InvalidHost
+from lxdock.test import FakeContainer
 
 
 class TestGuest:
@@ -27,15 +28,13 @@ class TestGuest:
 
     @unittest.mock.patch.object(Path, 'open')
     def test_can_return_ssh_pubkey(self, mock_open):
-        lxd_container = unittest.mock.Mock()
-        host = Host(lxd_container)
+        host = Host()
         assert host.get_ssh_pubkey()
         assert mock_open.call_count == 1
 
     @unittest.mock.patch('subprocess.Popen')
     def test_can_give_current_user_access_to_share(self, mocked_call):
-        lxd_container = unittest.mock.Mock()
-        host = Host(lxd_container)
+        host = Host()
         host.give_current_user_access_to_share('.')
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == 'setfacl -Rdm u:{}:rwX .'.format(os.getuid())
@@ -46,9 +45,8 @@ class TestGuest:
         class MockedContainer(object):
             name = 'test'
         mocked_stat.return_value = unittest.mock.MagicMock(st_uid='19958953')
-        lxd_container = MockedContainer()
-        host = Host(lxd_container)
-        host.give_mapped_user_access_to_share('.', '.')
+        host = Host()
+        host.give_mapped_user_access_to_share(FakeContainer(), '.', '.')
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0] == (
             'setfacl -Rm user:lxd:rwx,default:user:lxd:rwx,user:19958953:rwx,default:user:19958953'

--- a/tests/unit/provisioners/test_ansible.py
+++ b/tests/unit/provisioners/test_ansible.py
@@ -4,18 +4,19 @@ import unittest.mock
 from lxdock.guests import AlpineGuest, DebianGuest
 from lxdock.hosts import Host
 from lxdock.provisioners import AnsibleProvisioner
+from lxdock.test import FakeContainer
 
 
 class TestAnsibleProvisioner:
     @unittest.mock.patch('subprocess.Popen')
     def test_can_run_ansible_playbooks(self, mock_popen):
-        host = Host(unittest.mock.Mock())
-        guest = DebianGuest(unittest.mock.Mock())
+        host = Host()
+        guest = DebianGuest(FakeContainer())
         lxd_state = unittest.mock.Mock()
         lxd_state.network.__getitem__ = unittest.mock.MagicMock(
             return_value={'addresses': [{'family': 'init', 'address': '0.0.0.0', }, ]})
         guest.lxd_container.state.return_value = lxd_state
-        provisioner = AnsibleProvisioner('./', host, guest, {'playbook': 'deploy.yml'})
+        provisioner = AnsibleProvisioner('./', host, [guest], {'playbook': 'deploy.yml'})
         provisioner.provision()
         assert re.match(
             'ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook --inventory-file /[/\w]+ '
@@ -23,14 +24,14 @@ class TestAnsibleProvisioner:
 
     @unittest.mock.patch('subprocess.Popen')
     def test_can_run_ansible_playbooks_with_the_vault_password_file_option(self, mock_popen):
-        host = Host(unittest.mock.Mock())
-        guest = DebianGuest(unittest.mock.Mock())
+        host = Host()
+        guest = DebianGuest(FakeContainer())
         lxd_state = unittest.mock.Mock()
         lxd_state.network.__getitem__ = unittest.mock.MagicMock(
             return_value={'addresses': [{'family': 'init', 'address': '0.0.0.0', }, ]})
         guest.lxd_container.state.return_value = lxd_state
         provisioner = AnsibleProvisioner(
-            './', host, guest, {'playbook': 'deploy.yml', 'vault_password_file': '.vpass'})
+            './', host, [guest], {'playbook': 'deploy.yml', 'vault_password_file': '.vpass'})
         provisioner.provision()
         assert re.match(
             'ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook --inventory-file /[/\w]+ '
@@ -38,29 +39,31 @@ class TestAnsibleProvisioner:
 
     @unittest.mock.patch('subprocess.Popen')
     def test_can_run_ansible_playbooks_with_the_ask_vault_pass_option(self, mock_popen):
-        host = Host(unittest.mock.Mock())
-        guest = DebianGuest(unittest.mock.Mock())
+        host = Host()
+        guest = DebianGuest(FakeContainer())
         lxd_state = unittest.mock.Mock()
         lxd_state.network.__getitem__ = unittest.mock.MagicMock(
             return_value={'addresses': [{'family': 'init', 'address': '0.0.0.0', }, ]})
         guest.lxd_container.state.return_value = lxd_state
         provisioner = AnsibleProvisioner(
-            './', host, guest, {'playbook': 'deploy.yml', 'ask_vault_pass': True})
+            './', host, [guest], {'playbook': 'deploy.yml', 'ask_vault_pass': True})
         provisioner.provision()
         assert re.match(
             'ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook --inventory-file /[/\w]+ '
             '--ask-vault-pass ./deploy.yml', mock_popen.call_args[0][0])
 
     def test_can_properly_setup_ssh_for_alpine_guests(self):
-        lxd_container = unittest.mock.Mock()
+        container = FakeContainer()
+        lxd_container = container._container
         lxd_container.execute.return_value = ('ok', 'ok', '')
-        host = Host(unittest.mock.Mock())
-        guest = AlpineGuest(lxd_container)
-        provisioner = AnsibleProvisioner('./', host, guest, {'playbook': 'deploy.yml'})
+        host = Host()
+        guest = AlpineGuest(container)
+        provisioner = AnsibleProvisioner('./', host, [guest], {'playbook': 'deploy.yml'})
         provisioner.setup()
-        assert lxd_container.execute.call_count == 4
+        assert lxd_container.execute.call_count == 5
         assert lxd_container.execute.call_args_list[0][0] == (['apk', 'update'], )
         assert lxd_container.execute.call_args_list[1][0] == \
             (['apk', 'add'] + AnsibleProvisioner.guest_required_packages_alpine, )
         assert lxd_container.execute.call_args_list[2][0] == (['rc-update', 'add', 'sshd'], )
         assert lxd_container.execute.call_args_list[3][0] == (['/etc/init.d/sshd', 'start'], )
+        assert lxd_container.execute.call_args_list[4][0] == (['mkdir', '-p', '/root/.ssh'], )

--- a/tests/unit/provisioners/test_base.py
+++ b/tests/unit/provisioners/test_base.py
@@ -5,6 +5,7 @@ import pytest
 from lxdock.guests import DebianGuest
 from lxdock.provisioners import Provisioner
 from lxdock.provisioners.base import InvalidProvisioner
+from lxdock.test import FakeContainer
 
 
 class TestProvisioner:
@@ -27,11 +28,12 @@ class TestProvisioner:
 
             guest_required_packages_debian = ['test01', 'test02', ]
 
-        lxd_container = unittest.mock.Mock()
+        container = FakeContainer()
+        lxd_container = container._container
         lxd_container.execute.return_value = ('ok', 'ok', '')
         host = unittest.mock.Mock()
-        guest = DebianGuest(lxd_container)
-        provisioner = DummyProvisioner('./', host, guest, {})
+        guest = DebianGuest(container)
+        provisioner = DummyProvisioner('./', host, [guest], {})
         provisioner.setup()
         assert lxd_container.execute.call_count == 2
         assert lxd_container.execute.call_args_list[0][0] == \
@@ -45,13 +47,14 @@ class TestProvisioner:
             schema = {'test': 'test', }
             called = False
 
-            def setup_guest_debian(self):
+            def setup_guest_debian(self, guest):
                 self.called = True
 
-        lxd_container = unittest.mock.Mock()
+        container = FakeContainer()
+        lxd_container = container._container
         lxd_container.execute.return_value = ('ok', 'ok', '')
         host = unittest.mock.Mock()
-        guest = DebianGuest(lxd_container)
-        provisioner = DummyProvisioner('./', host, guest, {})
+        guest = DebianGuest(container)
+        provisioner = DummyProvisioner('./', host, [guest], {})
         provisioner.setup()
         assert provisioner.called

--- a/tests/unit/provisioners/test_puppet.py
+++ b/tests/unit/provisioners/test_puppet.py
@@ -58,10 +58,10 @@ class TestPuppetProvisioner:
     def test_can_run_puppet_manifest_mode(self, mock_run, mock_copy_dir):
         class DummyGuest(Guest):
             name = 'dummy'
-        host = Host(unittest.mock.Mock())
+        host = Host()
         guest = DummyGuest(unittest.mock.Mock())
         mock_run.return_value = 0
-        provisioner = PuppetProvisioner('./', host, guest, {
+        provisioner = PuppetProvisioner('./', host, [guest], {
             'manifest_file': 'test_site.pp',
             'manifests_path': 'test_manifests'})
         provisioner.provision()
@@ -84,10 +84,10 @@ class TestPuppetProvisioner:
     def test_can_run_puppet_environment_mode(self, mock_run, mock_copy_dir):
         class DummyGuest(Guest):
             name = 'dummy'
-        host = Host(unittest.mock.Mock())
+        host = Host()
         guest = DummyGuest(unittest.mock.Mock())
         mock_run.return_value = 0
-        provisioner = PuppetProvisioner('./', host, guest, {
+        provisioner = PuppetProvisioner('./', host, [guest], {
             'environment': 'test_production',
             'environment_path': 'test_environments'})
         provisioner.provision()
@@ -111,10 +111,10 @@ class TestPuppetProvisioner:
     def test_raise_error_if_puppet_is_not_found(self, mock_run, mock_copy_file):
         class DummyGuest(Guest):
             name = 'dummy'
-        host = Host(unittest.mock.Mock())
+        host = Host()
         guest = DummyGuest(unittest.mock.Mock())
         mock_run.return_value = 1  # Mock the error
-        provisioner = PuppetProvisioner('./', host, guest, {
+        provisioner = PuppetProvisioner('./', host, [guest], {
             'manifest_file': 'test_site.pp',
             'manifests_path': 'test_manifests'})
         with pytest.raises(ProvisionFailed):
@@ -128,10 +128,10 @@ class TestPuppetProvisioner:
     def test_can_set_binary_path(self, mock_run, mock_copy_dir):
         class DummyGuest(Guest):
             name = 'dummy'
-        host = Host(unittest.mock.Mock())
+        host = Host()
         guest = DummyGuest(unittest.mock.Mock())
         mock_run.return_value = 0
-        provisioner = PuppetProvisioner('./', host, guest, {
+        provisioner = PuppetProvisioner('./', host, [guest], {
             'manifest_file': 'test_site.pp',
             'manifests_path': 'test_manifests',
             'binary_path': '/test/path'})
@@ -150,10 +150,10 @@ class TestPuppetProvisioner:
     def test_can_set_facter(self, mock_run, mock_copy_dir):
         class DummyGuest(Guest):
             name = 'dummy'
-        host = Host(unittest.mock.Mock())
+        host = Host()
         guest = DummyGuest(unittest.mock.Mock())
         mock_run.return_value = 0
-        provisioner = PuppetProvisioner('./', host, guest, {
+        provisioner = PuppetProvisioner('./', host, [guest], {
             'manifest_file': 'site.pp',
             'manifests_path': 'test_manifests',
             'facter': {'foo': 'bah', 'bar': 'baz baz'}})
@@ -172,10 +172,10 @@ class TestPuppetProvisioner:
     def test_can_set_hiera_config_path(self, mock_run, mock_copy_dir, mock_copy_file):
         class DummyGuest(Guest):
             name = 'dummy'
-        host = Host(unittest.mock.Mock())
+        host = Host()
         guest = DummyGuest(unittest.mock.Mock())
         mock_run.return_value = 0
-        provisioner = PuppetProvisioner('./', host, guest, {
+        provisioner = PuppetProvisioner('./', host, [guest], {
             'manifest_file': 'site.pp',
             'manifests_path': 'test_manifests',
             'hiera_config_path': 'hiera.yaml'})
@@ -199,10 +199,10 @@ class TestPuppetProvisioner:
     def test_can_set_module_path(self, mock_run, mock_copy_dir):
         class DummyGuest(Guest):
             name = 'dummy'
-        host = Host(unittest.mock.Mock())
+        host = Host()
         guest = DummyGuest(unittest.mock.Mock())
         mock_run.return_value = 0
-        provisioner = PuppetProvisioner('./', host, guest, {
+        provisioner = PuppetProvisioner('./', host, [guest], {
             'manifest_file': 'mani.pp',
             'manifests_path': 'test_manifests',
             'module_path': 'test-puppet-modules'})
@@ -228,10 +228,10 @@ class TestPuppetProvisioner:
     def test_can_set_environment_variables(self, mock_run, mock_copy_dir):
         class DummyGuest(Guest):
             name = 'dummy'
-        host = Host(unittest.mock.Mock())
+        host = Host()
         guest = DummyGuest(unittest.mock.Mock())
         mock_run.return_value = 0
-        provisioner = PuppetProvisioner('./', host, guest, {
+        provisioner = PuppetProvisioner('./', host, [guest], {
             'manifest_file': 'site.pp',
             'manifests_path': 'test_manifests',
             'environment_variables': {'FOO': 'bah', 'BAR': 'baz baz'}})
@@ -249,10 +249,10 @@ class TestPuppetProvisioner:
     def test_can_set_options(self, mock_run, mock_copy_dir):
         class DummyGuest(Guest):
             name = 'dummy'
-        host = Host(unittest.mock.Mock())
+        host = Host()
         guest = DummyGuest(unittest.mock.Mock())
         mock_run.return_value = 0
-        provisioner = PuppetProvisioner('./', host, guest, {
+        provisioner = PuppetProvisioner('./', host, [guest], {
             'manifest_file': 'site.pp',
             'manifests_path': 'test_manifests',
             'options': '--a --c="test space" --b'})

--- a/tests/unit/provisioners/test_shell.py
+++ b/tests/unit/provisioners/test_shell.py
@@ -3,15 +3,16 @@ import unittest.mock
 from lxdock.guests import DebianGuest
 from lxdock.hosts import Host
 from lxdock.provisioners import ShellProvisioner
+from lxdock.test import FakeContainer
 
 
 class TestShellProvisioner:
     @unittest.mock.patch('subprocess.Popen')
     def test_can_run_commands_on_the_host_side(self, mock_popen):
-        host = Host(unittest.mock.Mock())
-        guest = DebianGuest(unittest.mock.Mock())
+        host = Host()
+        guest = DebianGuest(FakeContainer())
         provisioner = ShellProvisioner(
-            './', host, guest, {
+            './', host, [guest], {
                 'inline': """touch f && echo "Here's the PATH" $PATH >> /tmp/test.txt""",
                 'side': 'host', })
         provisioner.provision()
@@ -19,34 +20,34 @@ class TestShellProvisioner:
             """sh -c 'touch f && echo "Here'"'"'s the PATH" $PATH >> /tmp/test.txt'""", )
 
     def test_can_run_commands_on_the_guest_side(self):
-        lxd_container = unittest.mock.Mock()
-        lxd_container.execute.return_value = ('ok', 'ok', '')
-        host = Host(unittest.mock.Mock())
-        guest = DebianGuest(lxd_container)
+        container = FakeContainer()
+        lxd_container = container._container
+        host = Host()
+        guest = DebianGuest(container)
         cmd = """touch f && echo "Here's the PATH" $PATH >> /tmp/test.txt"""
         provisioner = ShellProvisioner(
-            './', host, guest, {'inline': cmd})
+            './', host, [guest], {'inline': cmd})
         provisioner.provision()
         assert lxd_container.execute.call_count == 1
         assert lxd_container.execute.call_args_list[0][0] == (['sh', '-c', cmd], )
 
     @unittest.mock.patch('subprocess.Popen')
     def test_can_run_a_script_on_the_host_side(self, mock_popen):
-        host = Host(unittest.mock.Mock())
+        host = Host()
         guest = DebianGuest(unittest.mock.Mock())
         provisioner = ShellProvisioner(
-            './', host, guest, {'script': 'test.sh', 'side': 'host', })
+            './', host, [guest], {'script': 'test.sh', 'side': 'host', })
         provisioner.provision()
         assert mock_popen.call_args[0] == ('./test.sh', )
 
     @unittest.mock.patch('builtins.open')
     def test_can_run_a_script_on_the_guest_side(self, mock_open):
-        lxd_container = unittest.mock.Mock()
-        lxd_container.execute.return_value = ('ok', 'ok', '')
-        host = Host(unittest.mock.Mock())
-        guest = DebianGuest(lxd_container)
+        container = FakeContainer()
+        lxd_container = container._container
+        host = Host()
+        guest = DebianGuest(container)
         provisioner = ShellProvisioner(
-            './', host, guest, {'script': 'test.sh', })
+            './', host, [guest], {'script': 'test.sh', })
         provisioner.provision()
         assert lxd_container.execute.call_count == 2
         assert lxd_container.execute.call_args_list[0][0] == (['chmod', '+x', '/tmp/test.sh', ], )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = True
 
 [testenv]
 deps =
-    -r{toxinidir}/requirements-dev.txt
+    -r{toxinidir}/requirements-tests.txt
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
 commands =


### PR DESCRIPTION
`provisioning` configuration items declared at the root are now applied
"globally" for provisioners that support it (only `ansible` for now).

Implementation of this feature required quite a refactoring to move the
provisioning logic around. In a nutshell: Less provisioning logic in
`Container` and more in `Provisioner` and `Project`.

One tricky matter was "when can we consider that a specific container
can have its `is_provisioned` flag set?". See code for answer.

I had to change quite many tests, so I used this opportunity to improve
tooling a bit to reduce code duplication in our tests, hence the
introduction of `FakeContainer`. I've only minimally applied its usage,
I'm sure this concept can be expanded and used elsewhere.

ref #88
