### PR TITLE
Make codecov relax

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,9 @@
+coverage:
+  status:
+    project:
+      target: 90
+      threshold: 1
+    patch:
+      target: 90
+      threshold: 1
 comment: off


### PR DESCRIPTION
These spurious failures caused by codecov are mightily annoying, even
with comments off. Red X in github are supposed to mean "DO NOT MERGE".
But the thing is, codecov checks are so tight that they trigger alarms
for perfectly good PR, which end up making us *ignore* those big red X
and thus beat the whole purpose behind them.