### PR TITLE
Make ansible use the "lxd" transport instead of ssh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,11 @@ matrix:
   allow_failures:
     - python: "3.7-dev"
 
+# We set HOME because lxc needs somewhere writable to not crash during testing.
 script:
-  - make travis
+  - cp -R /home/travis/.ssh $TRAVIS_BUILD_DIR
+  - HOME=$TRAVIS_BUILD_DIR make travis
+
 after_success:
   - codecov
 branches:

--- a/docs/provisioners/ansible.rst
+++ b/docs/provisioners/ansible.rst
@@ -84,4 +84,14 @@ This option is a hash of lists of container names. Example:
         group2:
           - container2
     
+lxd_transport
+=============
+
+If this boolean option is set to ``true``, we will use ansible's ``lxd`` transport instead of the
+``ssh`` one, thus bypassing ssh entirely and using ``lxc exec`` directly.
+
+It should be noted that while very cool-sounding, this transport method comes with a couple of
+drawbacks due to its incomplete support in Ansible. For example, ``synchronize`` actions don't
+work.
+
 .. _Ansible: https://www.ansible.com/

--- a/lxdock/provisioners/ansible.py
+++ b/lxdock/provisioners/ansible.py
@@ -15,26 +15,30 @@ class AnsibleProvisioner(Provisioner):
 
     name = 'ansible'
 
-    guest_required_packages_alpine = ['openssh', 'python', ]
-    guest_required_packages_arch = ['openssh', 'python', ]
-    guest_required_packages_centos = ['openssh-server', 'python', ]
-    guest_required_packages_debian = ['apt-utils', 'aptitude', 'openssh-server', 'python', ]
-    guest_required_packages_fedora = ['openssh-server', 'python2', ]
-    guest_required_packages_gentoo = ['net-misc/openssh', 'dev-lang/python', ]
-    guest_required_packages_opensuse = ['openSSH', 'python3-base', ]
-    guest_required_packages_ol = ['openssh-server', 'python', ]
-    guest_required_packages_ubuntu = ['apt-utils', 'aptitude', 'openssh-server', 'python', ]
+    guest_required_packages_alpine = ['python', ]
+    guest_required_packages_arch = ['python', ]
+    guest_required_packages_centos = ['python', ]
+    guest_required_packages_debian = ['apt-utils', 'aptitude', 'python', ]
+    guest_required_packages_fedora = ['python2', ]
+    guest_required_packages_gentoo = ['dev-lang/python', ]
+    guest_required_packages_opensuse = ['python3-base', ]
+    guest_required_packages_ol = ['python', ]
+    guest_required_packages_ubuntu = ['apt-utils', 'aptitude', 'python', ]
 
     schema = {
         Required('playbook'): IsFile(),
         'ask_vault_pass': bool,
         'vault_password_file': IsFile(),
         'groups': {Extra: [str, ]},
+        'lxd_transport': bool,
     }
 
     def get_inventory(self):
         def line(guest):
-            ip = get_ip(guest.lxd_container)
+            if self.options.get('lxd_transport'):
+                ip = guest.container.lxd_name
+            else:
+                ip = get_ip(guest.lxd_container)
             return '{} ansible_host={} ansible_user=root'.format(guest.container.name, ip)
 
         def fmtgroup(name, hosts):
@@ -56,36 +60,34 @@ class AnsibleProvisioner(Provisioner):
     def setup_single(self, guest):
         super().setup_single(guest)
 
+        if self.options.get('lxd_transport'):
+            # we don't need ssh
+            return
+
+        ssh_pkg_name = {
+            'alpine': 'openssh',
+            'arch': 'openssh',
+            'gentoo': 'net-misc/openssh',
+            'opensuse': 'openSSH',
+        }.get(guest.name, 'openssh-server')
+        guest.install_packages([ssh_pkg_name])
+
+        # Make sure that sshd is started
+        if guest.name == 'alpine':
+            guest.run(['rc-update', 'add', 'sshd'])
+            guest.run(['/etc/init.d/sshd', 'start'])
+        elif guest.name in {'arch', 'centos', 'fedora'}:
+            guest.run(['systemctl', 'enable', 'sshd'])
+            guest.run(['systemctl', 'start', 'sshd'])
+        elif guest.name == 'ol':
+            guest.run(['/sbin/service', 'sshd', 'start'])
+
         # Add the current user's SSH pubkey to the container's root SSH config.
         ssh_pubkey = self.host.get_ssh_pubkey()
         if ssh_pubkey is not None:
             guest.add_ssh_pubkey_to_root_authorized_keys(ssh_pubkey)
         else:
             logger.warning('SSH pubkey was not found. Provisioning tools may not work correctly...')
-
-    def setup_guest_alpine(self, guest):
-        # On alpine guests we have to ensure that ssd is started!
-        guest.run(['rc-update', 'add', 'sshd'])
-        guest.run(['/etc/init.d/sshd', 'start'])
-
-    def setup_guest_arch(self, guest):
-        # On archlinux guests we have to ensure that sshd is started!
-        guest.run(['systemctl', 'enable', 'sshd'])
-        guest.run(['systemctl', 'start', 'sshd'])
-
-    def setup_guest_centos(self, guest):
-        # On centos guests we have to ensure that sshd is started!
-        guest.run(['systemctl', 'enable', 'sshd'])
-        guest.run(['systemctl', 'start', 'sshd'])
-
-    def setup_guest_fedora(self, guest):
-        # On fedora guests we have to ensure that sshd is started!
-        guest.run(['systemctl', 'enable', 'sshd'])
-        guest.run(['systemctl', 'start', 'sshd'])
-
-    def setup_guest_ol(self, guest):
-        # On oracle linux guests we have to ensure that sshd is started!
-        guest.run(['/sbin/service', 'sshd', 'start'])
 
     ##################################
     # PRIVATE METHODS AND PROPERTIES #
@@ -94,7 +96,6 @@ class AnsibleProvisioner(Provisioner):
     def _build_ansible_playbook_command_args(self, inventory_filename):
         cmd_args = ['ANSIBLE_HOST_KEY_CHECKING=False', 'ansible-playbook', ]
         cmd_args.extend(['--inventory-file', inventory_filename, ])
-
         # Append the --ask-vault-pass option if applicable.
         if self.options.get('ask_vault_pass'):
             cmd_args.append('--ask-vault-pass')
@@ -104,6 +105,9 @@ class AnsibleProvisioner(Provisioner):
         if vault_password_file is not None:
             cmd_args.extend([
                 '--vault-password-file', self.homedir_expanded_path(vault_password_file)])
+
+        if self.options.get('lxd_transport'):
+            cmd_args.extend(['-c', 'lxd', ])
 
         # Append the playbook filepath and return the final command.
         cmd_args.append(self.homedir_expanded_path(self.options['playbook']))

--- a/lxdock/test/fakes.py
+++ b/lxdock/test/fakes.py
@@ -9,6 +9,7 @@ class FakeContainer(Container):
             client = Mock()
         options.setdefault('name', 'fakecontainer')
         super().__init__(project_name, homedir, client, **options)
+        self._lxd_name = "{}-{}-123".format(project_name, self.name)
 
     def _get_container(self, create=True):
         result = Mock()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,5 @@
 ipython>=5.1.0
 
-# Provisioners
-ansible>=2.1
-
 # Testing
 -r requirements-tests.txt
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,3 +1,4 @@
+ansible>=2.3
 codecov>=1.6
 pytest>=3.0
 pytest-cov>=1.8

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,10 @@ deps =
     -r{toxinidir}/requirements-tests.txt
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
+passenv = HOME
 commands =
     py.test
+whitelist_externals = lxc
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
The "lxd" transport in ansible allows us to provision our containers
without SSH, directly through "lxc exec" calls!

I had the idea for quite a while that I should explore the possibility
of plugging "lxc exec" into ansible, but I didn't know that the plug was
already there, ready to be used! Had I known that, I would have used it
from the start, it would have saved me SSH fiddling...

Also, you know that small "HOME=" line in tox.ini? I've spent **hours**
debugging this. My tests would fail **only** when running into tox, not
when running directly through pytest. That was very puzzling. Live and
learn...