### PR TITLE
Replace ubuntu/xenial with alpine/3.6 in integration tests

### DIFF
--- a/lxdock/test/fixtures.py
+++ b/lxdock/test/fixtures.py
@@ -35,7 +35,7 @@ def persistent_container():
     if _persistent_container is None:
         _persistent_container = Container(
             'lxdtestcase-persistentcontainer', THIS_DIR, get_client(), **{
-                'name': 'testcase-persistent', 'image': 'ubuntu/xenial', 'mode': 'pull',
+                'name': 'testcase-persistent', 'image': 'alpine/3.6', 'mode': 'pull',
             })
     # Ensures the persistent container is up and running.
     if not _persistent_container.exists \

--- a/tests/integration/fixtures/project01/lxdock.yml
+++ b/tests/integration/fixtures/project01/lxdock.yml
@@ -1,3 +1,3 @@
 name: lxdock-pytest-project01
-image: ubuntu/xenial
+image: alpine/3.6
 mode: pull

--- a/tests/integration/fixtures/project02/lxdock.yml
+++ b/tests/integration/fixtures/project02/lxdock.yml
@@ -1,5 +1,5 @@
 name: project02
-image: ubuntu/xenial
+image: alpine/3.6
 mode: pull
 
 containers:

--- a/tests/integration/fixtures/project03/lxdock.yml
+++ b/tests/integration/fixtures/project03/lxdock.yml
@@ -1,5 +1,5 @@
 name: project03
-image: ubuntu/xenial
+image: alpine/3.6
 mode: pull
 
 containers:

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -26,7 +26,7 @@ def test_must_be_created_and_running_decorator_works(persistent_container):
     del persistent_container.dummy_action
 
     non_created_container_options = {
-        'name': 'lxdock-nonexistingcontainer', 'image': 'ubuntu/xenial', 'mode': 'pull', }
+        'name': 'lxdock-nonexistingcontainer', 'image': 'alpine/3.6', 'mode': 'pull', }
     non_created_container = Container(
         'myproject', THIS_DIR, persistent_container.client, **non_created_container_options)
     non_created_container.dummy_action = types.MethodType(dummy_action, non_created_container)
@@ -36,7 +36,7 @@ def test_must_be_created_and_running_decorator_works(persistent_container):
 class TestContainer(LXDTestCase):
     def test_can_set_up_a_container_that_does_not_exist(self):
         container_options = {
-            'name': self.containername('newcontainer'), 'image': 'ubuntu/xenial', 'mode': 'pull', }
+            'name': self.containername('newcontainer'), 'image': 'alpine/3.6', 'mode': 'pull', }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.up()
         assert container._container.status_code == constants.CONTAINER_RUNNING
@@ -55,7 +55,7 @@ class TestContainer(LXDTestCase):
 
     def test_can_destroy_a_container_and_run_this_action_for_a_container_that_does_not_exist(self):
         container_options = {
-            'name': self.containername('doesnotexist'), 'image': 'ubuntu/xenial', 'mode': 'pull', }
+            'name': self.containername('doesnotexist'), 'image': 'alpine/3.6', 'mode': 'pull', }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.destroy()
         assert not container.exists
@@ -91,7 +91,7 @@ class TestContainer(LXDTestCase):
 
     def test_can_provision_a_container_shell_inline(self):
         container_options = {
-            'name': self.containername('willprovision'), 'image': 'ubuntu/xenial', 'mode': 'pull',
+            'name': self.containername('willprovision'), 'image': 'alpine/3.6', 'mode': 'pull',
             'environment': {'PATH': '/dummy_test:/bin:/usr/bin:/usr/local/bin'},
             'provisioning': [
                 {'type': 'shell',
@@ -114,7 +114,7 @@ class TestContainer(LXDTestCase):
     @unittest.mock.patch('subprocess.call')
     def test_can_open_a_shell_for_a_specific_shelluser(self, mocked_call):
         container_options = {
-            'name': self.containername('shellspecificuser'), 'image': 'ubuntu/xenial',
+            'name': self.containername('shellspecificuser'), 'image': 'alpine/3.6',
             'shell': {'user': 'test', 'home': '/opt', },
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
@@ -139,7 +139,7 @@ class TestContainer(LXDTestCase):
     @unittest.mock.patch('subprocess.call')
     def test_can_run_quoted_shell_command_for_a_specific_shelluser(self, mocked_call):
         container_options = {
-            'name': self.containername('shellspecificuser'), 'image': 'ubuntu/xenial',
+            'name': self.containername('shellspecificuser'), 'image': 'alpine/3.6',
             'shell': {'user': 'test', 'home': '/opt', },
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
@@ -156,7 +156,7 @@ class TestContainer(LXDTestCase):
     def test_can_set_shell_environment_variables(self, mocked_call):
         # Environment variables in the shell can be set through configuration.
         container_options = {
-            'name': self.containername('shell-env'), 'image': 'ubuntu/xenial',
+            'name': self.containername('shell-env'), 'image': 'alpine/3.6',
             'environment': {'FOO': 'bar', 'BAR': 42},
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
@@ -167,7 +167,7 @@ class TestContainer(LXDTestCase):
 
     def test_can_tell_if_a_container_exists_or_not(self, persistent_container):
         unknown_container = Container('myproject', THIS_DIR, self.client, **{
-            'name': self.containername('unknown'), 'image': 'ubuntu/xenial', 'mode': 'pull', })
+            'name': self.containername('unknown'), 'image': 'alpine/3.6', 'mode': 'pull', })
         assert persistent_container.exists
         assert not unknown_container.exists
 
@@ -201,7 +201,7 @@ class TestContainer(LXDTestCase):
 
     def test_can_return_its_status(self, persistent_container):
         unknown_container = Container('myproject', THIS_DIR, self.client, **{
-            'name': self.containername('unknown'), 'image': 'ubuntu/xenial', 'mode': 'pull', })
+            'name': self.containername('unknown'), 'image': 'alpine/3.6', 'mode': 'pull', })
         assert unknown_container.status == 'not-created'
         persistent_container.halt()
         assert persistent_container.status == 'stopped'
@@ -212,7 +212,7 @@ class TestContainer(LXDTestCase):
         password = '$6$cGzZBkDjOhGW$6C9wwqQteFEY4lQ6ZJBggE568SLSS7bIMKexwOD' \
                    '39mJQrJcZ5vIKJVIfwsKOZajhbPw0.Zqd0jU2NDLAnp9J/1'
         container_options = {
-            'name': self.containername('createusers'), 'image': 'ubuntu/xenial',
+            'name': self.containername('createusers'), 'image': 'alpine/3.6',
             'users': [
                 {'name': 'user01'},
                 {'name': 'user02', 'home': '/opt/user02'},
@@ -239,7 +239,7 @@ class TestContainer(LXDTestCase):
         # be passed directly to the container at creation time.
         container_options = {
             'name': self.containername('lxc-config'),
-            'image': 'ubuntu/xenial',
+            'image': 'alpine/3.6',
             'lxc_config': {
                 'security.privileged': 'invalid',
                 'user.lxdock.homedir': 'invalid',
@@ -276,7 +276,7 @@ class TestContainer(LXDTestCase):
 
     def test_can_set_profiles(self):
         container_options = {
-            'name': self.containername('newcontainer'), 'image': 'ubuntu/xenial', 'mode': 'pull',
+            'name': self.containername('newcontainer'), 'image': 'alpine/3.6', 'mode': 'pull',
             'profiles': ['default']}
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.up()
@@ -285,7 +285,7 @@ class TestContainer(LXDTestCase):
 
     def test_raises_an_error_if_profile_does_not_exist(self):
         container_options = {
-            'name': self.containername('newcontainer'), 'image': 'ubuntu/xenial', 'mode': 'pull',
+            'name': self.containername('newcontainer'), 'image': 'alpine/3.6', 'mode': 'pull',
             'profiles': ['default', '39mJQrJcZ5vIKJVIfwsKOZajhbPw0']}
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         with pytest.raises(ContainerOperationFailed):

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -27,7 +27,7 @@ class TestProject(LXDTestCase):
         assert project.containers[0].name == 'default'
         assert project.containers[0].homedir == homedir
         assert project.containers[0].options['mode'] == 'pull'
-        assert project.containers[0].options['image'] == 'ubuntu/xenial'
+        assert project.containers[0].options['image'] == 'alpine/3.6'
 
     def test_can_return_a_container_by_name(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project02')
@@ -84,7 +84,7 @@ class TestProject(LXDTestCase):
     def test_can_provision_all_the_containers_of_a_project(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
         container_options = {
-            'name': self.containername('dummytest'), 'image': 'ubuntu/xenial', 'mode': 'pull',
+            'name': self.containername('dummytest'), 'image': 'alpine/3.6', 'mode': 'pull',
         }
         provisioning_steps = [
             {'type': 'ansible',
@@ -101,7 +101,7 @@ class TestProject(LXDTestCase):
     def test_can_provision_some_specific_containers_of_a_project(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
         container_options = {
-            'name': self.containername('thisisatest'), 'image': 'ubuntu/xenial', 'mode': 'pull',
+            'name': self.containername('thisisatest'), 'image': 'alpine/3.6', 'mode': 'pull',
             'provisioning': [
                 {'type': 'ansible',
                  'playbook': os.path.join(THIS_DIR, 'fixtures/provision_with_ansible.yml'), }
@@ -119,7 +119,7 @@ class TestProject(LXDTestCase):
     def test_can_destroy_all_the_containers_of_a_project(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
         container_options = {
-            'name': self.containername('dummytest'), 'image': 'ubuntu/xenial',
+            'name': self.containername('dummytest'), 'image': 'alpine/3.6',
         }
         project = Project(
             'project02', homedir, self.client,


### PR DESCRIPTION
Alpine images are 2MB and xenial ones are 90MB!

On my machine, it makes the full test suite go from 356s to 182s, which
I think makes it very worthwhile!
