### PR TITLE
Release v0.4.0

### DIFF
--- a/docs/release_notes/v0.4.rst
+++ b/docs/release_notes/v0.4.rst
@@ -1,5 +1,5 @@
 ############################################
-LXDock 0.4 release notes (UNDER DEVELOPMENT)
+LXDock 0.4 release notes (2017-10-02)
 ############################################
 
 Requirements and compatibility

--- a/lxdock/__init__.py
+++ b/lxdock/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.4.0dev'
+__version__ = '0.4.0'


### PR DESCRIPTION
lxdock hasn't seen activity in a while and I'd like to use my lxd_transport option in my system-installed lxdock.

Besides, the recently-removed `requests<=2.16` hack in `setup.py` made my system lxdock complain when my system version of requests bumped up. I'd like to fix that.
