### PR TITLE
Allow wait timeout to be changed for IP

### DIFF
--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -33,6 +33,9 @@ def get_schema():
             'home': str,
             'password': str,
         }],
+        'extras': {
+            'network_wait_timeout': int
+        }
     }
 
     def _check_provisioner_config(config):

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -347,8 +347,9 @@ class Container:
         """ Setup the IP address of the considered container. """
         ip = get_ip(self._container)
         if not ip:
-            logger.info('No IP yet, waiting for at most 10 seconds...')
-            ip = self._wait_for_ip()
+            network_wait_timeout = self.options.get("extras", {}).get("network_wait_timeout", 10)
+            logger.info('No IP yet, waiting for at most {} seconds...'.format(network_wait_timeout))
+            ip = self._wait_for_ip(network_wait_timeout)
         if not ip:
             logger.warn('STILL no IP! Container is up, but probably broken.')
             logger.info('Maybe that restarting it will help? Not trying to provision.')


### PR DESCRIPTION
Some containers may be slow to boot up. The default 10 second wait might not be enough.
