### PR TITLE
Create user with a custom shell

### DIFF
--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -32,6 +32,7 @@ def get_schema():
             Required('name'): All(str, Length(max=32)),
             'home': str,
             'password': str,
+            'shell': str,
         }],
     }
 

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 import shlex
@@ -402,10 +403,9 @@ class Container:
 
         logger.info('Ensuring users are created...')
         for user_config in users:
-            name = user_config.get('name')
-            home = user_config.get('home')
-            password = user_config.get('password')
-            self._guest.create_user(name, home=home, password=password)
+            config = copy.copy(user_config)
+            name = config.pop('name')
+            self._guest.create_user(name, **config)
 
     def _unsetup_hostnames(self):
         """ Removes the configuration associated with the hostnames of the container. """

--- a/lxdock/guests/base.py
+++ b/lxdock/guests/base.py
@@ -117,13 +117,15 @@ class Guest(with_metaclass(_GuestBase)):
         self.run(['mkdir', '-p', '/root/.ssh'])
         self.lxd_container.files.put('/root/.ssh/authorized_keys', pubkey)
 
-    def create_user(self, username, home=None, password=None):
+    def create_user(self, username, home=None, password=None, shell=None):
         """ Adds the passed user to the container system. """
         options = ['--create-home', ]
         if home is not None:
             options += ['--home-dir', home, ]
         if password is not None:
             options += ['-p', password, ]
+        if shell is not None:
+            options += ['-s', shell, ]
         self.run(['useradd', ] + options + [username, ])
 
     ########################################################

--- a/tests/unit/guests/test_base.py
+++ b/tests/unit/guests/test_base.py
@@ -70,6 +70,16 @@ class TestGuest:
         assert guest.lxd_container.execute.call_args[0] == \
             (['useradd', '--create-home', '-p', password, 'usertest'], )
 
+    def test_can_create_a_user_with_a_custom_shell(self):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        guest = DummyGuest(FakeContainer())
+        shell = "/bin/zsh"
+        guest.create_user('usertest', shell=shell)
+        assert guest.lxd_container.execute.call_count == 1
+        assert guest.lxd_container.execute.call_args[0] == \
+            (['useradd', '--create-home', '-s', shell, 'usertest'], )
+
     def test_can_copy_file(self):
         class DummyGuest(Guest):
             name = 'dummy'


### PR DESCRIPTION
Some images like debian will just create new users with /bin/sh. Doing it via useradd is a lot less work than using something like ansible to provision the user with a particular shell.
