### PR TITLE
Install lxd with snap on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,7 @@
 sudo: required
 dist: trusty
 before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
-  - sudo apt-get -qq update
-  - sudo apt-get install -y lxd
-  - sudo lxd init --auto
-  - sudo lxc network create lxdbr0 ipv6.address=none ipv4.address=10.0.3.1/24 ipv4.nat=true
-  - sudo lxc network attach-profile lxdbr0 default eth0
-  - sudo chmod 777 /var/lib/lxd/unix.socket
-  - ssh-keygen -t rsa -b 2048 -f ~/.ssh/id_rsa -P ""
+  - scripts/travis-setup.sh
 
 language: python
 

--- a/lxdock/client.py
+++ b/lxdock/client.py
@@ -1,6 +1,17 @@
+import os
+from pkg_resources import parse_version as ver
+
 import pylxd
 
 
 def get_client():
     """ Returns a PyLXD client to be used to orchestrate containers. """
+    # Fixed a bug upstream: https://github.com/lxc/pylxd/issues/257
+    lxd_dir_not_set = "LXD_DIR" not in os.environ
+    snap_socket_exists = os.path.exists('/var/snap/lxd/common/lxd/unix.socket')
+    insufficient_version = ver(pylxd.__version__) < ver("2.2.5")
+
+    if lxd_dir_not_set and snap_socket_exists and insufficient_version:
+      os.environ["LXD_DIR"] = "/var/snap/lxd/common/lxd"
+
     return pylxd.Client()

--- a/lxdock/client.py
+++ b/lxdock/client.py
@@ -1,7 +1,7 @@
 import os
-from pkg_resources import parse_version as ver
 
 import pylxd
+from pkg_resources import parse_version as ver
 
 
 def get_client():
@@ -12,6 +12,6 @@ def get_client():
     insufficient_version = ver(pylxd.__version__) < ver("2.2.5")
 
     if lxd_dir_not_set and snap_socket_exists and insufficient_version:
-      os.environ["LXD_DIR"] = "/var/snap/lxd/common/lxd"
+        os.environ["LXD_DIR"] = "/var/snap/lxd/common/lxd"
 
     return pylxd.Client()

--- a/lxdock/client.py
+++ b/lxdock/client.py
@@ -1,17 +1,5 @@
-import os
-
 import pylxd
-from pkg_resources import parse_version as ver
 
 
 def get_client():
-    """ Returns a PyLXD client to be used to orchestrate containers. """
-    # Fixed a bug upstream: https://github.com/lxc/pylxd/issues/257
-    lxd_dir_not_set = "LXD_DIR" not in os.environ
-    snap_socket_exists = os.path.exists('/var/snap/lxd/common/lxd/unix.socket')
-    insufficient_version = ver(pylxd.__version__) < ver("2.2.5")
-
-    if lxd_dir_not_set and snap_socket_exists and insufficient_version:
-        os.environ["LXD_DIR"] = "/var/snap/lxd/common/lxd"
-
     return pylxd.Client()

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -18,3 +18,5 @@ sudo lxc network attach-profile lxdbr0 default eth0
 
 sudo chmod 777 /var/snap/lxd/common/lxd/unix.socket
 ssh-keygen -t rsa -b 2048 -f ~/.ssh/id_rsa -P ""
+
+pip install --upgrade pip setuptools

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -2,13 +2,19 @@
 
 set -xe
 
+sudo -E apt-get purge lxd lxd-client
 sudo -E apt-get install -y snapd
 sudo snap install lxd
 sudo snap list
 
-while [ ! -e /var/snap/lxd/common/lxd/unix.socket ]; do
-  sleep 0.1
+export PATH="/snap/bin:$PATH"
+sudo sh -c 'echo PATH=/snap/bin:$PATH >> /etc/environment'
+
+# lxd waitready
+while [ ! -S /var/snap/lxd/common/lxd/unix.socket ]; do
+  sleep 0.5
 done
+sudo usermod -a -G lxd travis
 
 sudo lxd --version
 
@@ -16,7 +22,4 @@ sudo lxd init --auto
 sudo lxc network create lxdbr0 ipv6.address=none ipv4.address=10.0.3.1/24 ipv4.nat=true
 sudo lxc network attach-profile lxdbr0 default eth0
 
-sudo chmod 777 /var/snap/lxd/common/lxd/unix.socket
-ssh-keygen -t rsa -b 2048 -f ~/.ssh/id_rsa -P ""
 
-pip install --upgrade pip setuptools

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -xe
+
+sudo -E apt-get install -y snapd
+sudo snap install lxd
+sudo snap list
+
+while [ ! -e /var/snap/lxd/common/lxd/unix.socket ]; do
+  sleep 0.1
+done
+
+sudo lxd --version
+
+sudo lxd init --auto
+sudo lxc network create lxdbr0 ipv6.address=none ipv4.address=10.0.3.1/24 ipv4.nat=true
+sudo lxc network attach-profile lxdbr0 default eth0
+
+sudo chmod 777 /var/snap/lxd/common/lxd/unix.socket
+ssh-keygen -t rsa -b 2048 -f ~/.ssh/id_rsa -P ""

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'colorlog>=2.0,<3.0',
-        'pylxd>=2.2.4',
+        'pylxd>=2.2.5',
         'python-dotenv>=0.6',
         'PyYAML>=3.0,<4.0',
         'voluptuous>=0.9,<1.0',

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -7,8 +7,8 @@ from lxdock import constants
 from lxdock.conf.config import Config
 from lxdock.container import Container
 from lxdock.exceptions import ProjectError
-from lxdock.project import logger as project_logger
 from lxdock.project import Project
+from lxdock.project import logger as project_logger
 from lxdock.test import LXDTestCase
 
 


### PR DESCRIPTION
Ubuntu deprecated the PPA and directed people to either use the backports or to use snap. Trusty-backport's version is too old. Thus we try to install this via snap, which means this PR requires #113.

Would be interesting/faster to use the docker version of travis to do this, but I'm not quite sure how it would be possible.

Also closes #103