### PR TITLE
lxdock + snap

### DIFF
--- a/lxdock/client.py
+++ b/lxdock/client.py
@@ -1,6 +1,17 @@
+import os
+from pkg_resources import parse_version as ver
+
 import pylxd
 
 
 def get_client():
     """ Returns a PyLXD client to be used to orchestrate containers. """
+    # Fixed a bug upstream: https://github.com/lxc/pylxd/issues/257
+    lxd_dir_not_set = "LXD_DIR" not in os.environ
+    snap_socket_exists = os.path.exists('/var/snap/lxd/common/lxd/unix.socket')
+    insufficient_version = ver(pylxd.__version__) < ver("2.2.5")
+
+    if lxd_dir_not_set and snap_socket_exists and insufficient_version:
+      os.environ["LXD_DIR"] = "/var/snap/lxd/common/lxd"
+
     return pylxd.Client()


### PR DESCRIPTION
Upstream has a bug: https://github.com/lxc/pylxd/issues/257

It is fixed in 2.2.5, which is yet to be released. This commit fixes this situation within lxdock.

Closes #103 
