### PR TITLE
 Use raw.idmap to map shared folders' permissions

### DIFF
--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -21,7 +21,7 @@ def get_schema():
             # The existence of the source directory will be checked!
             'source': IsDir(),
             'dest': str,
-            'set_host_acl': bool, # TODO: need a way to deprecate this
+            'set_host_acl': bool,  # TODO: need a way to deprecate this
         }],
         'shell': {
             'user': str,

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -21,7 +21,7 @@ def get_schema():
             # The existence of the source directory will be checked!
             'source': IsDir(),
             'dest': str,
-            'set_host_acl': bool,
+            'set_host_acl': bool, # TODO: need a way to deprecate this
         }],
         'shell': {
             'user': str,

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -25,7 +25,7 @@ def get_schema():
         }],
         'shell': {
             'user': str,
-            'home': str,
+            'home': str,  # TODO: deprecated
         },
         'users': [{
             # Usernames max length is set 32 characters according to useradd's man page.

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -122,12 +122,9 @@ class Container:
         shellcfg = self.options.get('shell', {})
         shelluser = username or shellcfg.get('user')
         if shelluser:
-            # This part is the result of quite a bit of `su` args trial-and-error.
-            shellhome = shellcfg.get('home') if not username else None
-            homearg = '--env HOME={}'.format(shellhome) if shellhome else ''
-            cmd = 'lxc exec {} {} -- su -m {}'.format(self.lxd_name, homearg, shelluser)
+            cmd = 'lxc exec {} -- su -l {}'.format(self.lxd_name, shelluser)
         else:
-            cmd = 'lxc exec {} -- su -m root'.format(self.lxd_name)
+            cmd = 'lxc exec {} -- su -l root'.format(self.lxd_name)
 
         if cmd_args:
             # Again, a bit of trial-and-error.

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -389,7 +389,9 @@ class Container:
 
         if raw_idmap_updated:
             # the container must be restarted for this to take effect
-            logger.info("share uid map (raw.idmap) updated, container must be restarted to take effect")
+            logger.info(
+              "share uid map (raw.idmap) updated, container must be restarted to take effect"
+            )
             container.restart(wait=True)
             self._setup_ip()
 

--- a/lxdock/guests/gentoo.py
+++ b/lxdock/guests/gentoo.py
@@ -11,6 +11,6 @@ class GentooGuest(Guest):
         # It contains "equery" that can check which package has been installed.
         self.run(['emerge', 'app-portage/gentoolkit'])
         for p in packages:
-            retcode = self.run(['equery', 'list', p])
+            retcode, _, _ = self.run(['equery', 'list', p])
             if retcode != 0:  # Not installed yet
                 self.run(['emerge', p])

--- a/lxdock/hosts/base.py
+++ b/lxdock/hosts/base.py
@@ -12,7 +12,6 @@ import shlex
 import subprocess
 from pathlib import Path
 
-from ..utils.lxd import get_lxd_dir
 from ..utils.metaclass import with_metaclass
 
 
@@ -126,7 +125,9 @@ class Host(with_metaclass(_HostBase)):
                 configured_correctly = False
 
         if not configured_correctly:
-            logger.error("you must set these lines and then restart the lxd daemon before continuing")
+            logger.error(
+              "you must set these lines and then restart the lxd daemon before continuing"
+            )
 
         return configured_correctly
 

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -121,7 +121,7 @@ class TestContainer(LXDTestCase):
         persistent_container.shell()
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
-            'lxc exec {} -- su -m root'.format(persistent_container.lxd_name)
+            'lxc exec {} -- su -l root'.format(persistent_container.lxd_name)
 
     @unittest.mock.patch('subprocess.call')
     def test_can_open_a_shell_for_a_specific_shelluser(self, mocked_call):
@@ -134,7 +134,7 @@ class TestContainer(LXDTestCase):
         container.shell()
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
-            'lxc exec {} --env HOME=/opt -- su -m test'.format(container.lxd_name)
+            'lxc exec {} -- su -l test'.format(container.lxd_name)
 
     @unittest.mock.patch('subprocess.call')
     def test_can_run_quoted_shell_command_for_the_root_user(
@@ -142,7 +142,7 @@ class TestContainer(LXDTestCase):
         persistent_container.shell(cmd_args=['echo', 'he re"s', '-u', '$PATH'])
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
-            'lxc exec {} -- su -m root -s {}'.format(
+            'lxc exec {} -- su -l root -s {}'.format(
                 persistent_container.lxd_name, persistent_container._guest_shell_script_file)
         script = persistent_container._container.files.get(
             persistent_container._guest_shell_script_file)
@@ -159,7 +159,7 @@ class TestContainer(LXDTestCase):
         container.shell(cmd_args=['echo', 'he re"s', '-u', '$PATH'])
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
-            'lxc exec {} --env HOME=/opt -- su -m test -s {}'.format(
+            'lxc exec {} -- su -l test -s {}'.format(
                 container.lxd_name, container._guest_shell_script_file)
         script = container._container.files.get(container._guest_shell_script_file)
         assert script == b"""#!/bin/sh\necho 'he re"s' -u '$PATH'\n"""

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -155,7 +155,7 @@ class TestProject(LXDTestCase):
         project.shell(container_name='testcase-persistent')
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
-            'lxc exec {} -- su -m root'.format(persistent_container.lxd_name)
+            'lxc exec {} -- su -l root'.format(persistent_container.lxd_name)
 
     @unittest.mock.patch('subprocess.call')
     def test_can_run_shell_command_for_a_specific_container(
@@ -165,7 +165,7 @@ class TestProject(LXDTestCase):
         project.shell(container_name='testcase-persistent', cmd_args=['echo', 'HELLO'])
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
-            "lxc exec {} -- su -m root -s {}".format(
+            "lxc exec {} -- su -l root -s {}".format(
                 persistent_container.lxd_name, persistent_container._guest_shell_script_file)
 
     @unittest.mock.patch.object(project_logger, 'info')

--- a/tests/unit/guests/test_base.py
+++ b/tests/unit/guests/test_base.py
@@ -119,3 +119,13 @@ class TestGuest:
 
         assert guest.lxd_container.files.put.call_count == 1
         assert guest.lxd_container.files.put.call_args[0][0] == guest._guest_temporary_tar_path
+
+    def test_uidgid(self):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        guest = DummyGuest(FakeContainer())
+        guest.lxd_container.execute.return_value = (0, "10000", "")
+
+        uid, gid = guest.uidgid("user")
+        assert uid == 10000
+        assert gid == 10000


### PR DESCRIPTION
Fixes #114 (lxdock shell doesn't set the correct env vars, commit 1) and #116 (shared folder issues, commit 2).

Fix for #116 is derived from https://stgraber.org/2017/06/15/custom-user-mappings-in-lxd-containers/.

This is kind of a WIP as there's no tests. Some finer points needs to be debated as well. A todo list is as follows:

- [x] We need to have a way to deprecate options in lxdock.yml without breaking old files.
- [x] How do we set /etc/subgid, /etc/subuid? Do we set it from lxdock or do we document this and let the user do it? Right now an error will show up telling user what to do.
- [ ] We need to remove the old documentation and document this new thing.
- [x] Tests.. Not sure if I'll have time to write it, especially considering that I can't consistently get the tests to pass. Perhaps we're better off merging this first and figure out the tests later.
- [ ] How do we clean up those setfacl calls from before? I think `setfacl -Rbn .` will work but this is not researched fully. Not sure if we need to address this, tho.
- [x] Which user do we map to? Right now it maps to either root or the first user in the users config. Not sure if this is a good idea long term, tho.

About setting up your system for this, you need to run:

```
printf "lxd:$(id -u):1\nroot:$(id -u):1\n" | sudo tee -a /etc/subuid
printf "lxd:$(id -g):1\nroot:$(id -g):1\n" | sudo tee -a /etc/subgid
sudo systemctl restart lxd
```

Demonstration of how this works:

```
[thinkpadw530:~/projects/test-lxdock]$ ls -l
total 16
-rw-rw-r-- 1 shuhao shuhao    7 Mar  4 00:25 abc
-rw-rw-r-- 1 shuhao shuhao    5 Mar  4 00:25 bde
drwxrwxr-x 8 shuhao shuhao 4096 Mar  3 23:03 lxdock
-rw-r--r-- 1 shuhao shuhao  192 Mar  4 00:38 lxdock.yml
[thinkpadw530:~/projects/test-lxdock]$ cat lxdock.yml
name: test-lxdock
image: ubuntu/xenial

containers:
  - name: test-lxdock
    users:
      - name: dev

    shell:
      user: dev

    shares:
      - source: .
        dest: /home/dev/share
[thinkpadw530:~/projects/test-lxdock]$ lxdock up
Bringing container "test-lxdock" up
==> test-lxdock: Starting container "test-lxdock"...
==> test-lxdock: No IP yet, waiting for at most 10 seconds...
==> test-lxdock: Container "test-lxdock" is up! IP: 10.28.173.212
==> test-lxdock: Ensuring users are created...
==> test-lxdock: Setting up shares...
==> test-lxdock: share uid map (raw.idmap) updated, container must be restarted to take effect
==> test-lxdock: No IP yet, waiting for at most 10 seconds...
[thinkpadw530:~/projects/test-lxdock]$ lxdock shell
dev@test-lxdock-test-lxdock-23307078:~$ cd share/ && ls -l && cat abc
total 16
-rw-rw-r-- 1 dev dev    7 Mar  4 05:25 abc
-rw-rw-r-- 1 dev dev    5 Mar  4 05:25 bde
drwxrwxr-x 8 dev dev 4096 Mar  4 04:03 lxdock
-rw-r--r-- 1 dev dev  192 Mar  4 05:38 lxdock.yml
adfadf
dev@test-lxdock-test-lxdock-23307078:~/share$ echo "guest" > guestfile
dev@test-lxdock-test-lxdock-23307078:~/share$ ls -l guestfile 
-rw-rw-r-- 1 dev dev 6 Mar  4 05:40 guestfile
dev@test-lxdock-test-lxdock-23307078:~/share$ logout
[thinkpadw530:~/projects/test-lxdock]$ ls -l
total 20
-rw-rw-r-- 1 shuhao shuhao    7 Mar  4 00:25 abc
-rw-rw-r-- 1 shuhao shuhao    5 Mar  4 00:25 bde
-rw-rw-r-- 1 shuhao shuhao    6 Mar  4 00:40 guestfile
drwxrwxr-x 8 shuhao shuhao 4096 Mar  3 23:03 lxdock
-rw-r--r-- 1 shuhao shuhao  192 Mar  4 00:38 lxdock.yml
```

r: @robvdl