### PR TITLE
Tests are working again on Travis using snap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,6 @@
-sudo: required
-dist: trusty
-before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
-  - sudo apt-get -qq update
-  - sudo apt-get install -y lxd
-  - sudo lxd init --auto
-  - sudo lxc network create lxdbr0 ipv6.address=none ipv4.address=10.0.3.1/24 ipv4.nat=true
-  - sudo lxc network attach-profile lxdbr0 default eth0
-  - sudo chmod 777 /var/lib/lxd/unix.socket
-  - ssh-keygen -t rsa -b 2048 -f ~/.ssh/id_rsa -P ""
-
 language: python
+sudo: true
+dist: trusty
 
 python:
   - "3.4"
@@ -22,13 +12,28 @@ matrix:
   allow_failures:
     - python: "3.7-dev"
 
+install:
+  - make travis-sysdeps
+  - ssh-keygen -t rsa -b 2048 -f ~/.ssh/id_rsa -P ""
+
+env:
+  global:
+    - PATH=/snap/bin:$PATH
+
+before_script:
+  - sudo addgroup lxd || true
+  - sudo usermod -a -G lxd $USER || true
+  - sudo ln -s /snap/bin/lxc /usr/bin/lxc
+
 # We set HOME because lxc needs somewhere writable to not crash during testing.
+# The "sudo -E" line is needed because the user was added to the lxd group which needs to be applied.
 script:
   - cp -R /home/travis/.ssh $TRAVIS_BUILD_DIR
-  - HOME=$TRAVIS_BUILD_DIR make travis
+  - sudo -E sudo -u $USER -E bash -c 'source ~/virtualenv/python$TRAVIS_PYTHON_VERSION/bin/activate; HOME=$TRAVIS_BUILD_DIR make travis'
 
 after_success:
   - codecov
+
 branches:
   only:
     - master

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,10 @@
 
 install:
 	pip install -r requirements-dev.txt
-	# Temporary while we need a dev version of pylxd
 	pip install -e .
 
 upgrade:
 	pip install -r requirements-dev.txt -U
-	# Temporary while we need a dev version of pylxd
 	pip install -e . -U
 
 lint:
@@ -21,6 +19,22 @@ coverage:
 
 spec:
 	py.test --spec -p no:sugar
+
+travis-sysdeps:
+	sudo apt-get update -q
+	sudo apt-get remove -qy lxd lxd-client
+	sudo apt-get -y install snapd
+	sudo snap install lxd
+	sudo snap list
+	sudo snap start lxd
+	sudo sh -c 'echo PATH=/snap/bin:$$PATH >> /etc/environment'
+	while [ ! -S /var/snap/lxd/common/lxd/unix.socket ]; do \
+		sleep 0.5; \
+	done
+	sudo lxd --version
+	sudo lxd init --auto
+	sudo lxc network create lxdbr0 ipv6.address=none ipv4.address=10.0.3.1/24 ipv4.nat=true
+	sudo lxc network attach-profile lxdbr0 default eth0
 
 travis: install lint isort coverage
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,5 @@ isort>=4.2
 flake8>=2.2.5
 
 # Docs
-Sphinx>=1.3
+Sphinx==1.5.6
 sphinx-rtd-theme>=0.1

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -7,8 +7,8 @@ from lxdock import constants
 from lxdock.conf.config import Config
 from lxdock.container import Container
 from lxdock.exceptions import ProjectError
-from lxdock.project import logger as project_logger
 from lxdock.project import Project
+from lxdock.project import logger as project_logger
 from lxdock.test import LXDTestCase
 
 


### PR DESCRIPTION
This commit is a squashed version of last 40 commits in PR #119

* Use snap version of lxd and continue to use Trusty for now as it seems more reliable
* Fix import ordering in test_project.py that seems to have come from an updated version of isort
* Move Travis setup to Makefile where lxd is installed from snap and a network setup
* Needed to use sudo -E workaround to apply lxd group to travis user before running tests
* Pin version of Sphinx used because latest version was going into a recursion loop during pip install