### PR TITLE
Fix shell -c command is now like Vagrant

### DIFF
--- a/contrib/completion/zsh/_lxdock
+++ b/contrib/completion/zsh/_lxdock
@@ -94,10 +94,10 @@ case $state in
         ;;
 
       (shell)
-        # lxdock shell name [-h] [-u USERNAME] [-c ...]
+        # lxdock shell name [-h] [-u USERNAME] [-c COMMAND]
         _arguments '::container:__container_list' \
                    '(-u --username)'{-u,--username}'[Username to login as]:username:' \
-                   '(-c --command)'{-c,--command}'[Command to be executed]:*command:command:'
+                   '(-c --command)'{-c,--command}'[Command to be executed]:command:'
         ;;
 
       (status)

--- a/lxdock/cli/main.py
+++ b/lxdock/cli/main.py
@@ -83,8 +83,7 @@ class LXDock:
         self._parsers['shell'].add_argument(
             '-u', '--username', help='Username to login as.')
         self._parsers['shell'].add_argument(
-            '-c', '--command', nargs=argparse.REMAINDER, dest='cmd_args',
-            help='Command to be executed.')
+            '-c', '--command', nargs='?', help='Command to be executed.')
 
         # Creates the 'status' action.
         self._parsers['status'] = subparsers.add_parser(
@@ -216,7 +215,7 @@ class LXDock:
 
     def shell(self, args):
         self.project.shell(
-            container_name=args.name, username=args.username, cmd_args=args.cmd_args)
+            container_name=args.name, username=args.username, command=args.command)
 
     def status(self, args):
         self.project.status(container_names=args.name)

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -127,7 +127,7 @@ class TestContainer(LXDTestCase):
     def test_can_open_a_shell_for_a_specific_shelluser(self, mocked_call):
         container_options = {
             'name': self.containername('shellspecificuser'), 'image': 'alpine/3.6',
-            'shell': {'user': 'test', 'home': '/opt', },
+            'shell': {'user': 'test'},
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.up()
@@ -137,32 +137,32 @@ class TestContainer(LXDTestCase):
             'lxc exec {} -- su -l test'.format(container.lxd_name)
 
     @unittest.mock.patch('subprocess.call')
-    def test_can_run_quoted_shell_command_for_the_root_user(
+    def test_can_run_shell_command_for_the_root_user(
             self, mocked_call, persistent_container):
-        persistent_container.shell(cmd_args=['echo', 'he re"s', '-u', '$PATH'])
+        persistent_container.shell(command='cd /; ls -l')
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
             'lxc exec {} -- su -l root -s {}'.format(
                 persistent_container.lxd_name, persistent_container._guest_shell_script_file)
         script = persistent_container._container.files.get(
             persistent_container._guest_shell_script_file)
-        assert script == b"""#!/bin/sh\necho 'he re"s' -u '$PATH'\n"""
+        assert script == b"""#!/bin/sh\ncd /; ls -l\n"""
 
     @unittest.mock.patch('subprocess.call')
-    def test_can_run_quoted_shell_command_for_a_specific_shelluser(self, mocked_call):
+    def test_can_run_shell_command_for_a_specific_shelluser(self, mocked_call):
         container_options = {
             'name': self.containername('shellspecificuser'), 'image': 'alpine/3.6',
-            'shell': {'user': 'test', 'home': '/opt', },
+            'shell': {'user': 'test'},
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.up()
-        container.shell(cmd_args=['echo', 'he re"s', '-u', '$PATH'])
+        container.shell(command='cd /; ls -l')
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
             'lxc exec {} -- su -l test -s {}'.format(
                 container.lxd_name, container._guest_shell_script_file)
         script = container._container.files.get(container._guest_shell_script_file)
-        assert script == b"""#!/bin/sh\necho 'he re"s' -u '$PATH'\n"""
+        assert script == b"""#!/bin/sh\ncd /; ls -l\n"""
 
     @unittest.mock.patch('subprocess.call')
     def test_can_set_shell_environment_variables(self, mocked_call):

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -162,7 +162,7 @@ class TestProject(LXDTestCase):
             self, mocked_call, persistent_container):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
         project = Project('project02', homedir, self.client, [persistent_container, ], [])
-        project.shell(container_name='testcase-persistent', cmd_args=['echo', 'HELLO'])
+        project.shell(container_name='testcase-persistent', command='echo "HELLO"')
         assert mocked_call.call_count == 1
         assert mocked_call.call_args[0][0] == \
             "lxc exec {} -- su -l root -s {}".format(

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -152,7 +152,7 @@ class TestLXDock:
         LXDock(['shell'])
         assert mock_project_shell.call_count == 1
         assert mock_project_shell.call_args == [{
-            'container_name': None, 'username': None, 'cmd_args': None}, ]
+            'container_name': None, 'username': None, 'command': None}, ]
 
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'shell')
@@ -163,7 +163,7 @@ class TestLXDock:
         LXDock(['shell', 'c1'])
         assert mock_project_shell.call_count == 1
         assert mock_project_shell.call_args == [{
-            'container_name': 'c1', 'username': None, 'cmd_args': None}, ]
+            'container_name': 'c1', 'username': None, 'command': None}, ]
 
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'shell')
@@ -173,29 +173,29 @@ class TestLXDock:
         LXDock(['shell', '-u', 'foobar'])
         assert mock_project_shell.call_count == 1
         assert mock_project_shell.call_args == [{
-            'container_name': None, 'username': 'foobar', 'cmd_args': None}, ]
+            'container_name': None, 'username': 'foobar', 'command': None}, ]
 
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'shell')
     def test_can_run_shell_command_for_a_specific_container(self, mock_project_shell, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock(['shell', 'c1', '-c', 'echo', 'he re"s', '-u', '$PATH'])
+        LXDock(['shell', 'c1', '-c', 'cd /; ls -l'])
         assert mock_project_shell.call_count == 1
         assert mock_project_shell.call_args == [{
             'container_name': 'c1', 'username': None,
-            'cmd_args': ['echo', 'he re\"s', '-u', '$PATH']}, ]
+            'command': 'cd /; ls -l'}, ]
 
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'shell')
     def test_can_run_shell_command_for_a_specific_user(self, mock_project_shell, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock(['shell', '-u', 'foobar', '-c', 'echo', 'he re"s', '-u', '$PATH'])
+        LXDock(['shell', '-u', 'foobar', '-c', 'cd /; ls -l'])
         assert mock_project_shell.call_count == 1
         assert mock_project_shell.call_args == [{
             'container_name': None, 'username': 'foobar',
-            'cmd_args': ['echo', 'he re\"s', '-u', '$PATH']}, ]
+            'command': 'cd /; ls -l'}, ]
 
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'shell')
@@ -203,11 +203,11 @@ class TestLXDock:
             self, mock_project_shell, mock_project):
         mock_project.__get__ = unittest.mock.Mock(
             return_value=get_project(os.path.join(FIXTURE_ROOT, 'project01')))
-        LXDock(['shell', '-u', 'foobar', 'c1', '-c', 'echo', 'he re"s', '-u', '$PATH'])
+        LXDock(['shell', '-u', 'foobar', 'c1', '-c', 'cd /; ls -l'])
         assert mock_project_shell.call_count == 1
         assert mock_project_shell.call_args == [{
             'container_name': 'c1', 'username': 'foobar',
-            'cmd_args': ['echo', 'he re\"s', '-u', '$PATH']}, ]
+            'command': 'cd /; ls -l'}, ]
 
     @unittest.mock.patch.object(LXDock, 'project')
     @unittest.mock.patch.object(Project, 'status')


### PR DESCRIPTION
The shell command feature did not seem to work when running two commands because it was using shlex.quote on each argument.

See: issue #129

With the current syntax I was unable to work out how to simply run two commands in a container, Vagrant uses this much simpler syntax which makes much more sense:

    vagrant ssh -c "command1; command2"

Also Vagrant will produce an error if you add another argument so this will not work:

    vagrant ssh -c command1 command2

It seemed lxdock followed something like that except it auto quoted each argument, it was quite confusing and I couldn't figure out how two run two commands and that produced an error.

I have changed lxdock to be the same as how vagrant works:

    lxdock shell -c "command1; command2"

Fixed tests and updated zsh config, the bash one doesn't need updating by the looks of it.

Closes #129