### PR TITLE
Updating docs for 0.5 release part 1

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -28,6 +28,15 @@ get a working copy of the project using the following commands (eg. using Python
   $ python3.6 -m venv ./env && . ./env/bin/activate
   $ make install
 
+Instead of setting up an environment directly on your development machine itself,
+you can also use the included Vagrantfile for creating a test environment:
+
+.. code-block:: bash
+
+  $ vagrant up
+  $ vagrant ssh
+  $ make coverage
+
 Coding style
 ############
 
@@ -64,8 +73,9 @@ You can run the whole test suite using the following command:
 
   $ py.test
 
-Code coverage should not decrease with pull requests! You can easily get the code coverage of the
-project using the following command:
+Code coverage should not decrease with pull requests if possible but may be
+discussed with the maintainer on a Github issue if required. You can easily get
+the code coverage of the project using the following command:
 
 .. code-block:: bash
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -73,9 +73,11 @@ You can run the whole test suite using the following command:
 
   $ py.test
 
-Code coverage should not decrease with pull requests if possible but may be
-discussed with the maintainer on a Github issue if required. You can easily get
-the code coverage of the project using the following command:
+Code coverage should not decrease with pull requests but in some cases we
+realise that isn't always possible, in which case it can then be discussed with
+the maintainers on a Github issue, so that there is some history about this.
+
+You can easily get the code coverage of the project using the following command:
 
 .. code-block:: bash
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -74,8 +74,8 @@ You can run the whole test suite using the following command:
   $ py.test
 
 Code coverage should not decrease with pull requests but in some cases we
-realise that isn't always possible, in which case it can then be discussed with
-the maintainers on a Github issue, so that there is some history about this.
+realise that isn't always possible. If this happen it should be discussed on
+a Github issue with the maintainers, so that there is some history about this.
 
 You can easily get the code coverage of the project using the following command:
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -75,7 +75,7 @@ You can run the whole test suite using the following command:
 
 Code coverage should not decrease with pull requests but in some cases we
 realise that isn't always possible. If this happen it should be discussed on
-a Github issue with the maintainers, so that there is some history about this.
+a Github issue with the maintainers, so that there is a record of it.
 
 You can easily get the code coverage of the project using the following command:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -22,14 +22,14 @@ Prerequisite: install LXD
 You may want to skip this section if you already have a working installation
 of LXD on your system.
 
-For Debian or Ubuntu 16.04 and higher if you prefer to stick with apt:
+LXD is available in the repository for Debian or Ubuntu 16.04 and higher:
 
 .. code-block:: console
 
   $ sudo apt-get install lxd
 
 You can now also install LXD from Snap which works on Ubuntu 14.04 and higher.
-Since the PPA has been deprecated, this is now the easiest way to get
+Since the LXD PPA has been deprecated, this is now the easiest way to get
 the latest version of LXD on Ubuntu.
 
 .. note::

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -37,7 +37,7 @@ the latest version of LXD on Ubuntu.
   If you have already installed and configured LXD from apt earlier and
   want to upgrade to the Snap version, you may need to purge LXD packages
   first and reboot for the old network bridge to be removed. You can migrate
-  existing containers using ``lxd.migrate`` after or just start fresh.
+  existing containers using ``lxd.migrate`` or just start fresh.
 
   .. code-block:: console
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -22,7 +22,7 @@ Prerequisite: install LXD
 You may want to skip this section if you already have a working installation
 of LXD on your system.
 
-For Debian or Ubuntu 16.04 and higher if prefer to stick with apt:
+For Debian or Ubuntu 16.04 and higher if you prefer to stick with apt:
 
 .. code-block:: console
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -120,9 +120,10 @@ You should now be able to install LXDock using:
 .. note::
 
   It is good practice to install lxdock in a virtualenv rather than installing
-  it globally as root, but make sure you create a python3 virtualenv.
-  To use lxdock from any location without having to activate the virtualenv,
-  you can create a symlink ``/usr/bin/lxdock`` to the virtualenv bin/lxdock.
+  it globally as root, but make sure you always use a python3 virtualenv.
+  To use lxdock from any location without having to activate this virtualenv,
+  you can create a symlink from the lxdock executable in the virtualenv to
+  ``/usr/bin/lxdock`` or ``/usr/local/bin/lxdock``.
 
 .. note::
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,7 +6,6 @@ Requirements
 
 * `Python`_ 3.4+
 * `LXD`_ 2.0+
-* ``getfacl/setfacl`` if you plan to use shared folders
 * any provisioning tool you wish to use with LXDock
 
 .. _Python: https://www.python.org
@@ -20,32 +19,46 @@ LXDock should build very easily on Linux provided you have LXD available on your
 Prerequisite: install LXD
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You may want to skip this section if you already have a working installation of LXD on your system.
+You may want to skip this section if you already have a working installation
+of LXD on your system.
 
-For Debian and Ubuntu, the following command will ensure that LXD is installed:
+For Debian or Ubuntu 16.04 and higher if prefer to stick with apt:
 
 .. code-block:: console
 
   $ sudo apt-get install lxd
 
+You can now also install LXD from Snap which works on Ubuntu 14.04 and higher.
+Since the PPA has been deprecated, this is now the easiest way to get
+the latest version of LXD on Ubuntu.
+
 .. note::
 
-  If you're using an old version of Ubuntu you should first add the LXD's apt repository and install
-  the ``lxd`` package as follows:
+  If you have already installed and configured LXD from apt earlier and
+  want to upgrade to the Snap version, you may need to purge LXD packages
+  first and reboot for the old network bridge to be removed. You can migrate
+  existing containers using ``lxd.migrate`` after or just start fresh.
 
   .. code-block:: console
 
-    $ sudo add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
-    $ sudo apt-get update
-    $ sudo apt-get install lxd
+    $ sudo apt-get purge lxd lxd-client
 
-For Fedora, LXD is available through an experimental COPR repository. Unfortunately SELinux is not
-yet supported, therefore make sure it is disabled or set to permissive. Then run:
+To install LXD from a Snap instead of apt:
 
 .. code-block:: console
 
-    # dnf copr enable ganto/lxd
-    # dnf install lxd lxd-tools
+  $ sudo apt-get install snapd
+  $ sudo snap install lxd
+  $ sudo snap start lxd
+
+For Fedora, LXD is available through an experimental COPR repository.
+Unfortunately SELinux is not yet supported, therefore make sure it is
+disabled or set to permissive. Then run:
+
+.. code-block:: console
+
+  $ dnf copr enable ganto/lxd
+  $ dnf install lxd lxd-tools
 
 You should now be able to configure your LXD installation using:
 
@@ -77,6 +90,24 @@ You can now check if your LXD installation is working using:
 
   You can use ``lxc stop first-machine`` to stop the previously created container.
 
+Prepare host for shared folders
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+LXDock uses ``raw.idmap`` for shared folders to so that files on the share
+that are owned by the host user appear to be owned by the container user
+inside the container, even if new files are created inside the container.
+
+To use shares, the following needs to be run once to prepare the host,
+then LXD needs to be restarted.
+
+.. code-block:: console
+
+  $ printf "lxd:$(id -u):1\nroot:$(id -u):1\n" | sudo tee -a /etc/subuid
+  $ printf "lxd:$(id -g):1\nroot:$(id -g):1\n" | sudo tee -a /etc/subgid
+
+To restart LXD use ``sudo snap restart lxd`` or ``sudo service restart lxd``
+or equivalent for your system.
+
 Install LXDock
 ~~~~~~~~~~~~~~
 
@@ -85,6 +116,13 @@ You should now be able to install LXDock using:
 .. code-block:: console
 
   $ pip3 install lxdock
+
+.. note::
+
+  It is good practice to install lxdock in a virtualenv rather than installing
+  it globally as root, but make sure you create a python3 virtualenv.
+  To use lxdock from any location without having to activate the virtualenv,
+  you can create a symlink ``/usr/bin/lxdock`` to the virtualenv bin/lxdock.
 
 .. note::
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -34,7 +34,7 @@ configuration options of LXDock.
     Privileged container
         Privileged containers are containers where the root user (in the container) is mapped to the
         host's root user. This is not really "root-safe" and could lead to potential security
-        flawns. That said it should be noted that privileged containers come with some protection
+        flaws. That said it should be noted that privileged containers come with some protection
         mechanisms in order to protect the host. You can refer to `LXC's documentation
         <https://linuxcontainers.org/fr/lxc/security/>`_ for more details on this topic.
 


### PR DESCRIPTION
* Mostly updating the get_started.rst page and documenting Snap installation method
* Also add recommendation about installing lxdock in a virtualenv to discourage sudo pip installs
* Add note about migrating from apt to Snap version of LXD without going into too much detail
* Add section to getting_started.rst about setting up the host for shares and remove setfacl reference
* Mention Vagrant test box in contributing.rst page
* Don't be too assertive about coverage (exclamation mark), yes we want to be strict, but sometimes a small drop is unavoidable and should be discussable on an issue
* Found one typo in glossary.rst