### PR TITLE
Expanduser for shares as well as additional share properties.

### DIFF
--- a/lxdock/conf/config.py
+++ b/lxdock/conf/config.py
@@ -75,7 +75,7 @@ class Config:
         config.interpolate()
 
         try:
-            schema(config._dict)
+            config._dict = schema(config._dict)
         except Invalid as e:
             # Formats the voluptuous error
             path = ' @ %s' % '.'.join(map(str, e.path)) if e.path else ''

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -1,8 +1,7 @@
-from voluptuous import (ALLOW_EXTRA, All, Any, Coerce, Extra, In, IsDir, Length, Required, Schema,
-                        Url)
+from voluptuous import ALLOW_EXTRA, All, Any, Coerce, Extra, In, Length, Required, Schema, Url
 
 from ..provisioners import Provisioner
-from .validators import Hostname, LXDIdentifier
+from .validators import Hostname, IsDirAfterExpandUser, LXDIdentifier
 
 
 def get_schema():
@@ -18,8 +17,7 @@ def get_schema():
         'provisioning': [],  # will be set dynamically using provisioner classes...
         'server': Url(),
         'shares': [{
-            # The existence of the source directory will be checked!
-            'source': IsDir(),
+            'source': IsDirAfterExpandUser,
             'dest': str,
             'set_host_acl': bool,  # TODO: need a way to deprecate this
         }],

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -1,7 +1,7 @@
 from voluptuous import ALLOW_EXTRA, All, Any, Coerce, Extra, In, Length, Required, Schema, Url
 
 from ..provisioners import Provisioner
-from .validators import Hostname, IsDirAfterExpandUser, LXDIdentifier
+from .validators import ExpandUserIfExists, Hostname, LXDIdentifier
 
 
 def get_schema():
@@ -17,9 +17,10 @@ def get_schema():
         'provisioning': [],  # will be set dynamically using provisioner classes...
         'server': Url(),
         'shares': [{
-            'source': IsDirAfterExpandUser,
+            'source': ExpandUserIfExists,
             'dest': str,
             'set_host_acl': bool,  # TODO: need a way to deprecate this
+            'share_properties': {Extra: Coerce(str)},
         }],
         'shell': {
             'user': str,

--- a/lxdock/conf/validators.py
+++ b/lxdock/conf/validators.py
@@ -1,5 +1,7 @@
+import os.path
 import re
 
+from voluptuous import Invalid
 from voluptuous.schema_builder import message
 from voluptuous.validators import truth
 
@@ -29,3 +31,14 @@ def LXDIdentifier(v):
     if len(v) > 63:
         return False
     return lxd_identifier_re.match(v)
+
+
+def IsDirAfterExpandUser(path):
+    if type(path) != str:
+        raise Invalid("expected a string path")
+
+    path = os.path.expanduser(path)
+    if not os.path.isdir(path):
+        raise Invalid("expected path {} to exists".format(path))
+
+    return path

--- a/lxdock/conf/validators.py
+++ b/lxdock/conf/validators.py
@@ -33,12 +33,8 @@ def LXDIdentifier(v):
     return lxd_identifier_re.match(v)
 
 
-def IsDirAfterExpandUser(path):
+def ExpandUserIfExists(path):
     if type(path) != str:
         raise Invalid("expected a string path")
 
-    path = os.path.expanduser(path)
-    if not os.path.isdir(path):
-        raise Invalid("expected path {} to exists".format(path))
-
-    return path
+    return os.path.expanduser(path)

--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -376,6 +376,18 @@ class Container:
         for i, share in enumerate(self.options.get('shares', []), start=1):
             source = os.path.join(self.homedir, share['source'])
             shareconf = {'type': 'disk', 'source': source, 'path': share['dest'], }
+
+            extra_properties = share.pop('share_properties', {})
+            extra_properties.pop("type", None)
+            extra_properties.pop("source", None)
+            extra_properties.pop("path", None)
+            shareconf.update(extra_properties)
+
+            # Upstream issue: https://github.com/lxc/lxd/issues/4538
+            if shareconf.get("optional", "false").lower() in {"true", "1", "on", "yes"}:
+                if not os.path.exists(source):
+                    continue
+
             container.devices['lxdockshare%s' % i] = shareconf
 
         guest_username = self.options.get("users", [{"name": "root"}])[0]["name"]

--- a/tests/unit/conf/test_validators.py
+++ b/tests/unit/conf/test_validators.py
@@ -1,10 +1,9 @@
 import os.path
 
 import pytest
-from voluptuous import Invalid
 from voluptuous.error import ValueInvalid
 
-from lxdock.conf.validators import Hostname, IsDirAfterExpandUser, LXDIdentifier
+from lxdock.conf.validators import ExpandUserIfExists, Hostname, LXDIdentifier
 
 
 class TestHostnameValidator:
@@ -48,11 +47,7 @@ class TestLXDIdentifier:
             id_validator('i' * 64)
 
 
-class TestIsDirAfterExpandUser:
+class TestExpandUserIfExists:
     def test_converts_dir_if_encountering_tilde(self):
-        expanded_path = IsDirAfterExpandUser("~/.ssh")
+        expanded_path = ExpandUserIfExists("~/.ssh")
         assert expanded_path == os.path.expanduser("~/.ssh")
-
-    def test_raise_invalid_if_not_directory(self):
-        with pytest.raises(Invalid):
-            IsDirAfterExpandUser("/adkfjak/adfkjakf/adkfjakjdf")

--- a/tests/unit/conf/test_validators.py
+++ b/tests/unit/conf/test_validators.py
@@ -1,7 +1,10 @@
+import os.path
+
 import pytest
+from voluptuous import Invalid
 from voluptuous.error import ValueInvalid
 
-from lxdock.conf.validators import Hostname, LXDIdentifier
+from lxdock.conf.validators import Hostname, IsDirAfterExpandUser, LXDIdentifier
 
 
 class TestHostnameValidator:
@@ -43,3 +46,13 @@ class TestLXDIdentifier:
         assert id_validator('i' * 63)
         with pytest.raises(ValueInvalid):
             id_validator('i' * 64)
+
+
+class TestIsDirAfterExpandUser:
+    def test_converts_dir_if_encountering_tilde(self):
+        expanded_path = IsDirAfterExpandUser("~/.ssh")
+        assert expanded_path == os.path.expanduser("~/.ssh")
+
+    def test_raise_invalid_if_not_directory(self):
+        with pytest.raises(Invalid):
+            IsDirAfterExpandUser("/adkfjak/adfkjakf/adkfjakjdf")


### PR DESCRIPTION
Allows shares to be specified with ~ on the host.

This allows one to share things like .ssh/.gnupg and other stuff easier into the container.

Additionally, I'm adding an entry to allow the specification of additional disk options as documented by https://github.com/lxc/lxd/blob/master/doc/containers.md#type-disk

@robvdl 
