### PR TITLE
Pin ansible < 2.5 to keep supporting Python 3.4

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,4 @@
-ansible>=2.3
+ansible>=2.3,<2.5
 codecov>=1.6
 pytest>=3.0
 pytest-cov>=1.8


### PR DESCRIPTION
It appears that Ansible 2.5 no longer supports Python 3.4

Since Ubuntu 14.04 LTS is still supported which comes with Python 3.4, we should pin Ansible at least until April 2019 when Ubuntu 14.04 goes out of support.

After that period we could possibly remove the Python 3.4 job on Travis and start testing against 3.7 instead