### PR TITLE
Allow users to become sudoers automatically

### DIFF
--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -32,6 +32,7 @@ def get_schema():
             'home': str,
             'password': str,
             'shell': str,
+            'sudoer': bool,
         }],
         'extras': {
             'network_wait_timeout': int

--- a/lxdock/guests/base.py
+++ b/lxdock/guests/base.py
@@ -118,7 +118,7 @@ class Guest(with_metaclass(_GuestBase)):
         self.run(['mkdir', '-p', '/root/.ssh'])
         self.lxd_container.files.put('/root/.ssh/authorized_keys', pubkey)
 
-    def create_user(self, username, home=None, password=None, shell=None):
+    def create_user(self, username, home=None, password=None, shell=None, sudoer=False):
         """ Adds the passed user to the container system. """
         options = ['--create-home', ]
         if home is not None:
@@ -127,7 +127,12 @@ class Guest(with_metaclass(_GuestBase)):
             options += ['-p', password, ]
         if shell is not None:
             options += ['-s', shell, ]
+
         self.run(['useradd', ] + options + [username, ])
+
+        if sudoer:
+            content = '{} ALL=(ALL) NOPASSWD:ALL'.format(username)
+            self.lxd_container.files.put("/etc/sudoers.d/{}_sudoer".format(username), content)
 
     def uidgid(self, username):
         """Obtain the uid and gid """


### PR DESCRIPTION
This PR introduces a `sudoer` option for each user, which will automatically add the user to the list of passwordless sudoers in the container. It is accomplished via files in /etc/sudoers.d, which should be supported in most distros afaik.

This should eliminate some unnecessary provisioning step and streamline the process. 

r: @robvdl 