### PR TITLE
Correctly set the SHELL variable

### DIFF
--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -140,6 +140,7 @@ class Container:
             self._container.files.put(self._guest_shell_script_file, textwrap.dedent(
                 """\
                 #!/bin/sh
+                export SHELL=/bin/sh
                 {}
                 """.format(command)))
             self._guest.run(['chmod', 'a+rx', self._guest_shell_script_file])


### PR DESCRIPTION
Right now, since we are launching shell commands by first transferring a script and then launching the script as if it is a shell (see man su for the -s option), it sets the SHELL environment variable to the script.

Some applications relies on using the SHELL environment variable to launch subprocesses, which could result in a forkbomb. This PR fixes this behaviour by setting the SHELL to /bin/sh, which is accurate.

r: @robvdl 