### PR TITLE
Fix Travis CI tests, lxd init already sets up a bridge now

### DIFF
--- a/scripts/ci-base-setup.sh
+++ b/scripts/ci-base-setup.sh
@@ -20,9 +20,8 @@ done
 user=`whoami`
 sudo usermod -a -G lxd ${user}
 
+# lxd init now sets up a bridge so we no longer need to
 sudo lxd init --auto
-sudo lxc network create lxdbr0 ipv6.address=none ipv4.address=10.0.3.1/24 ipv4.nat=true
-sudo lxc network attach-profile lxdbr0 default eth0
 
 # ansible test needs ssh
 if [ ! -f $HOME/.ssh/id_rsa ]; then

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'colorlog>=2.0,<3.0',
-        'pylxd>=2.2.5',
+        'pylxd>=2.2.5,<2.2.7',  # See: https://github.com/lxc/pylxd/issues/316
         'python-dotenv>=0.6',
         'PyYAML>=3.0,<4.0',
         'voluptuous>=0.9,<1.0',


### PR DESCRIPTION
Tests were failing because the bridge already existed.