### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: true
 dist: trusty
 
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ dist: bionic
 python:
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8"
 
 matrix:
   allow_failures:
-    - python: "3.7-dev"
+    - python: "3.7"
+    - python: "3.8"
 
 install:
   - scripts/ci-base-setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: true
-dist: trusty
+dist: bionic
 
 python:
   - "3.5"

--- a/lxdock/test/fixtures.py
+++ b/lxdock/test/fixtures.py
@@ -35,12 +35,17 @@ def persistent_container():
     if _persistent_container is None:
         _persistent_container = Container(
             'lxdtestcase-persistentcontainer', THIS_DIR, get_client(), **{
-                'name': 'testcase-persistent', 'image': 'alpine/3.6', 'mode': 'pull',
+                'name': 'testcase-persistent', 'image': 'alpine/3.11', 'mode': 'pull',
             })
     # Ensures the persistent container is up and running.
     if not _persistent_container.exists \
             or (_persistent_container.exists and _persistent_container.is_stopped):
         _persistent_container.up()
+    # We need to set a root password in the container, otherwise ssh login is blocked
+    # See https://alpinelinux.org/posts/Docker-image-vulnerability-CVE-2019-5021.html
+    exit_code, stdout, stderr = _persistent_container._container.execute(
+        ['/usr/bin/passwd'], stdin_payload=('n0tASecurePassw0rd\nn0tASecurePassw0rd'))
+    assert exit_code == 0
     return _persistent_container
 
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
 ansible>=2.3,<2.5
 codecov>=1.6
-pytest>=3.0
+pytest>=3.6
 pytest-cov>=1.8
 pytest-spec>=0.2
 pytest-sugar>=0.7.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'colorlog>=2.0,<3.0',
-        'pylxd>=2.2.5,<2.2.7',  # See: https://github.com/lxc/pylxd/issues/316
+        'pylxd>=2.2.10',
         'python-dotenv>=0.6',
         'PyYAML>=3.0,<4.0',
         'voluptuous>=0.9,<1.0',

--- a/tests/integration/fixtures/project01/lxdock.yml
+++ b/tests/integration/fixtures/project01/lxdock.yml
@@ -1,3 +1,3 @@
 name: lxdock-pytest-project01
-image: alpine/3.6
+image: alpine/3.10
 mode: pull

--- a/tests/integration/fixtures/project02/lxdock.yml
+++ b/tests/integration/fixtures/project02/lxdock.yml
@@ -1,5 +1,5 @@
 name: project02
-image: alpine/3.6
+image: alpine/3.10
 mode: pull
 
 containers:

--- a/tests/integration/fixtures/project03/lxdock.yml
+++ b/tests/integration/fixtures/project03/lxdock.yml
@@ -1,5 +1,5 @@
 name: project03
-image: alpine/3.6
+image: alpine/3.10
 mode: pull
 
 containers:

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -27,7 +27,7 @@ def test_must_be_created_and_running_decorator_works(persistent_container):
     del persistent_container.dummy_action
 
     non_created_container_options = {
-        'name': 'lxdock-nonexistingcontainer', 'image': 'alpine/3.6', 'mode': 'pull', }
+        'name': 'lxdock-nonexistingcontainer', 'image': 'alpine/3.10', 'mode': 'pull', }
     non_created_container = Container(
         'myproject', THIS_DIR, persistent_container.client, **non_created_container_options)
     non_created_container.dummy_action = types.MethodType(dummy_action, non_created_container)
@@ -37,7 +37,7 @@ def test_must_be_created_and_running_decorator_works(persistent_container):
 class TestContainer(LXDTestCase):
     def test_can_set_up_a_container_that_does_not_exist(self):
         container_options = {
-            'name': self.containername('newcontainer'), 'image': 'alpine/3.6', 'mode': 'pull', }
+            'name': self.containername('newcontainer'), 'image': 'alpine/3.10', 'mode': 'pull', }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.up()
         assert container._container.status_code == constants.CONTAINER_RUNNING
@@ -56,7 +56,7 @@ class TestContainer(LXDTestCase):
 
     def test_can_destroy_a_container_and_run_this_action_for_a_container_that_does_not_exist(self):
         container_options = {
-            'name': self.containername('doesnotexist'), 'image': 'alpine/3.6', 'mode': 'pull', }
+            'name': self.containername('doesnotexist'), 'image': 'alpine/3.10', 'mode': 'pull', }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.destroy()
         assert not container.exists
@@ -67,7 +67,7 @@ class TestContainer(LXDTestCase):
 
     def test_halting_a_container_doesnt_create_it(self):
         container_options = {
-            'name': self.containername('doesnotexist'), 'image': 'alpine/3.6', }
+            'name': self.containername('doesnotexist'), 'image': 'alpine/3.10', }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.halt()
         assert not container.exists
@@ -103,7 +103,7 @@ class TestContainer(LXDTestCase):
 
     def test_can_provision_a_container_shell_inline(self):
         container_options = {
-            'name': self.containername('willprovision'), 'image': 'alpine/3.6', 'mode': 'pull',
+            'name': self.containername('willprovision'), 'image': 'alpine/3.10', 'mode': 'pull',
             'environment': {'PATH': '/dummy_test:/bin:/usr/bin:/usr/local/bin'},
             'provisioning': [
                 {'type': 'shell',
@@ -126,7 +126,7 @@ class TestContainer(LXDTestCase):
     @unittest.mock.patch('subprocess.call')
     def test_can_open_a_shell_for_a_specific_shelluser(self, mocked_call):
         container_options = {
-            'name': self.containername('shellspecificuser'), 'image': 'alpine/3.6',
+            'name': self.containername('shellspecificuser'), 'image': 'alpine/3.10',
             'shell': {'user': 'test'},
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
@@ -151,7 +151,7 @@ class TestContainer(LXDTestCase):
     @unittest.mock.patch('subprocess.call')
     def test_can_run_shell_command_for_a_specific_shelluser(self, mocked_call):
         container_options = {
-            'name': self.containername('shellspecificuser'), 'image': 'alpine/3.6',
+            'name': self.containername('shellspecificuser'), 'image': 'alpine/3.10',
             'shell': {'user': 'test'},
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
@@ -168,7 +168,7 @@ class TestContainer(LXDTestCase):
     def test_can_set_shell_environment_variables(self, mocked_call):
         # Environment variables in the shell can be set through configuration.
         container_options = {
-            'name': self.containername('shell-env'), 'image': 'alpine/3.6',
+            'name': self.containername('shell-env'), 'image': 'alpine/3.10',
             'environment': {'FOO': 'bar', 'BAR': 42},
         }
         container = Container('myproject', THIS_DIR, self.client, **container_options)
@@ -179,7 +179,7 @@ class TestContainer(LXDTestCase):
 
     def test_can_tell_if_a_container_exists_or_not(self, persistent_container):
         unknown_container = Container('myproject', THIS_DIR, self.client, **{
-            'name': self.containername('unknown'), 'image': 'alpine/3.6', 'mode': 'pull', })
+            'name': self.containername('unknown'), 'image': 'alpine/3.10', 'mode': 'pull', })
         assert persistent_container.exists
         assert not unknown_container.exists
 
@@ -213,7 +213,7 @@ class TestContainer(LXDTestCase):
 
     def test_can_return_its_status(self, persistent_container):
         unknown_container = Container('myproject', THIS_DIR, self.client, **{
-            'name': self.containername('unknown'), 'image': 'alpine/3.6', 'mode': 'pull', })
+            'name': self.containername('unknown'), 'image': 'alpine/3.10', 'mode': 'pull', })
         assert unknown_container.status == 'not-created'
         persistent_container.halt()
         assert persistent_container.status == 'stopped'
@@ -224,7 +224,7 @@ class TestContainer(LXDTestCase):
         password = '$6$cGzZBkDjOhGW$6C9wwqQteFEY4lQ6ZJBggE568SLSS7bIMKexwOD' \
                    '39mJQrJcZ5vIKJVIfwsKOZajhbPw0.Zqd0jU2NDLAnp9J/1'
         container_options = {
-            'name': self.containername('createusers'), 'image': 'alpine/3.6',
+            'name': self.containername('createusers'), 'image': 'alpine/3.10',
             'users': [
                 {'name': 'user01'},
                 {'name': 'user02', 'home': '/opt/user02'},
@@ -251,7 +251,7 @@ class TestContainer(LXDTestCase):
         # be passed directly to the container at creation time.
         container_options = {
             'name': self.containername('lxc-config'),
-            'image': 'alpine/3.6',
+            'image': 'alpine/3.10',
             'lxc_config': {
                 'security.privileged': 'invalid',
                 'user.lxdock.homedir': 'invalid',
@@ -288,7 +288,7 @@ class TestContainer(LXDTestCase):
 
     def test_can_set_profiles(self):
         container_options = {
-            'name': self.containername('newcontainer'), 'image': 'alpine/3.6', 'mode': 'pull',
+            'name': self.containername('newcontainer'), 'image': 'alpine/3.10', 'mode': 'pull',
             'profiles': ['default']}
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         container.up()
@@ -297,7 +297,7 @@ class TestContainer(LXDTestCase):
 
     def test_raises_an_error_if_profile_does_not_exist(self):
         container_options = {
-            'name': self.containername('newcontainer'), 'image': 'alpine/3.6', 'mode': 'pull',
+            'name': self.containername('newcontainer'), 'image': 'alpine/3.10', 'mode': 'pull',
             'profiles': ['default', '39mJQrJcZ5vIKJVIfwsKOZajhbPw0']}
         container = Container('myproject', THIS_DIR, self.client, **container_options)
         with pytest.raises(ContainerOperationFailed):

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -27,7 +27,7 @@ class TestProject(LXDTestCase):
         assert project.containers[0].name == 'default'
         assert project.containers[0].homedir == homedir
         assert project.containers[0].options['mode'] == 'pull'
-        assert project.containers[0].options['image'] == 'alpine/3.6'
+        assert project.containers[0].options['image'] == 'alpine/3.10'
 
     def test_can_return_a_container_by_name(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project02')
@@ -84,7 +84,7 @@ class TestProject(LXDTestCase):
     def test_can_provision_all_the_containers_of_a_project(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
         container_options = {
-            'name': self.containername('dummytest'), 'image': 'alpine/3.6', 'mode': 'pull',
+            'name': self.containername('dummytest'), 'image': 'alpine/3.10', 'mode': 'pull',
         }
         provisioning_steps = [
             {'type': 'ansible',
@@ -101,7 +101,7 @@ class TestProject(LXDTestCase):
     def test_can_provision_some_specific_containers_of_a_project(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
         container_options = {
-            'name': self.containername('thisisatest'), 'image': 'alpine/3.6', 'mode': 'pull',
+            'name': self.containername('thisisatest'), 'image': 'alpine/3.10', 'mode': 'pull',
             'provisioning': [
                 {'type': 'ansible',
                  'playbook': os.path.join(THIS_DIR, 'fixtures/provision_with_ansible.yml'), }
@@ -119,7 +119,7 @@ class TestProject(LXDTestCase):
     def test_can_destroy_all_the_containers_of_a_project(self):
         homedir = os.path.join(FIXTURE_ROOT, 'project03')
         container_options = {
-            'name': self.containername('dummytest'), 'image': 'alpine/3.6',
+            'name': self.containername('dummytest'), 'image': 'alpine/3.10',
         }
         project = Project(
             'project02', homedir, self.client,

--- a/tests/unit/conf/test_schema.py
+++ b/tests/unit/conf/test_schema.py
@@ -81,4 +81,4 @@ class TestValidateProvisionerSchemas:
                     'b': 'yes'
                 }]
             })
-        assert "['provisioning'][1]['a']" in str(e)
+            assert "['provisioning'][1]['a']" in str(e)

--- a/tests/unit/provisioners/test_ansible.py
+++ b/tests/unit/provisioners/test_ansible.py
@@ -29,7 +29,7 @@ class TestAnsibleProvisioner:
         provisioner.provision()
         m = re.match(
             r'ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook --inventory-file /[/\w]+ '
-            '(.*)\s?./deploy.yml', mock_popen.call_args[0][0])
+            r'(.*)\s?./deploy.yml', mock_popen.call_args[0][0])
         assert m
         assert m.group(1).strip() == expected_cmdargs
 


### PR DESCRIPTION
Travis build currently fails.

### linting 

The linting in the travis build failed, due to a newer flake8 version. See https://github.com/MathSci/fecon236/issues/6 for reference.
Prefixing the string holding a regex with `r` (according to the current python conventions) fixes that.

### pytest version

Newer versions of pycov require a newer version of pytest.

### alpine update

The tests used *alpine/3.6* as a test image, which does not exist anymore in the standard remote. Version bump to 3.11.

The new version of alpine requires a root password to be set manually, otherwise SSH (and thus ansible) won't work.

### Use newer pylxd version

In the past, the pylxd version used (in the tests) was restricted to 2.2.7 (due to an upstream bug mentioned in #155), but this broke with the introduction of #163 which used newer API signatures.
The upstream bug has been fixed, so an update to at least 2.2.10 is possible

### Indentation error

One schema test had an indentation error. I guess it never worked before.

### Python 3.4

The deprecated python version 3.4 has been removed from the build