### PR TITLE
Install SSH key in authorized_keys of all users created by lxdock

### DIFF
--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -424,7 +424,8 @@ class Container:
                     home_dir = '/home/'+name
                     if 'home' in config:
                         home_dir = config['home']
-                    self._guest.add_ssh_pubkey_to_authorized_keys(ssh_pubkey, home_dir)
+                    uid, gid = self._guest.uidgid(name)
+                    self._guest.add_ssh_pubkey_to_authorized_keys(ssh_pubkey, home_dir, uid, gid)
 
         # Add the current user's SSH pubkey to the container's root SSH config.
         if ssh_pubkey is not None:

--- a/lxdock/guests/base.py
+++ b/lxdock/guests/base.py
@@ -112,15 +112,14 @@ class Guest(with_metaclass(_GuestBase)):
         class_ = next((k for k in cls.guests if k.detect(container._container)), Guest)
         return class_(container)
 
-    def add_ssh_pubkey_to_authorized_keys(self, pubkey, homedir):
+    def add_ssh_pubkey_to_authorized_keys(self, pubkey, homedir, uid=None, gid=None):
         """ Add a given SSH public key to the root user's authorized keys. """
         logger.info("Adding {} to machine's authorized keys in home directory {}."
                     .format(pubkey, homedir))
         ssh_dir = '{}/.ssh'.format(homedir)
         authorized_keys_file = '{}/authorized_keys'.format(ssh_dir)
-        # TODO: Set UID of files
         self.run(['mkdir', '-p', ssh_dir])
-        self.lxd_container.files.put(authorized_keys_file, pubkey)
+        self.lxd_container.files.put(authorized_keys_file, pubkey, uid=uid, gid=gid)
 
     def create_user(self, username, home=None, password=None, shell=None):
         """ Adds the passed user to the container system. """

--- a/lxdock/guests/base.py
+++ b/lxdock/guests/base.py
@@ -112,11 +112,15 @@ class Guest(with_metaclass(_GuestBase)):
         class_ = next((k for k in cls.guests if k.detect(container._container)), Guest)
         return class_(container)
 
-    def add_ssh_pubkey_to_root_authorized_keys(self, pubkey):
+    def add_ssh_pubkey_to_authorized_keys(self, pubkey, homedir):
         """ Add a given SSH public key to the root user's authorized keys. """
-        logger.info("Adding {} to machine's authorized keys".format(pubkey))
-        self.run(['mkdir', '-p', '/root/.ssh'])
-        self.lxd_container.files.put('/root/.ssh/authorized_keys', pubkey)
+        logger.info("Adding {} to machine's authorized keys in home directory {}."
+                    .format(pubkey, homedir))
+        ssh_dir = '{}/.ssh'.format(homedir)
+        authorized_keys_file = '{}/authorized_keys'.format(ssh_dir)
+        # TODO: Set UID of files
+        self.run(['mkdir', '-p', ssh_dir])
+        self.lxd_container.files.put(authorized_keys_file, pubkey)
 
     def create_user(self, username, home=None, password=None, shell=None):
         """ Adds the passed user to the container system. """

--- a/lxdock/provisioners/ansible.py
+++ b/lxdock/provisioners/ansible.py
@@ -84,13 +84,6 @@ class AnsibleProvisioner(Provisioner):
         elif guest.name == 'ol':
             guest.run(['/sbin/service', 'sshd', 'start'])
 
-        # Add the current user's SSH pubkey to the container's root SSH config.
-        ssh_pubkey = self.host.get_ssh_pubkey()
-        if ssh_pubkey is not None:
-            guest.add_ssh_pubkey_to_root_authorized_keys(ssh_pubkey)
-        else:
-            logger.warning('SSH pubkey was not found. Provisioning tools may not work correctly...')
-
     ##################################
     # PRIVATE METHODS AND PROPERTIES #
     ##################################

--- a/tests/unit/guests/test_base.py
+++ b/tests/unit/guests/test_base.py
@@ -41,6 +41,18 @@ class TestGuest:
         assert guest.lxd_container.files.put.call_args[0] == \
             ('/root/.ssh/authorized_keys', 'pubkey', )
 
+    def test_setup_users_adds_ssh_pubkey_to_authorized_keys(self):
+        class DummyGuest(Guest):
+            name = 'dummy'
+        container = FakeContainer()
+        container._setup_users()
+        guest = DummyGuest(container)
+        assert guest.lxd_container.execute.call_count == 1
+        assert guest.lxd_container.execute.call_args[0] == (['mkdir', '-p', '/root/.ssh'], )
+        assert guest.lxd_container.files.put.call_count == 1
+        assert guest.lxd_container.files.put.call_args[0][0] == \
+            '/root/.ssh/authorized_keys'
+
     def test_can_create_a_user_with_a_default_home_directory(self):
         class DummyGuest(Guest):
             name = 'dummy'

--- a/tests/unit/guests/test_base.py
+++ b/tests/unit/guests/test_base.py
@@ -34,7 +34,7 @@ class TestGuest:
         class DummyGuest(Guest):
             name = 'dummy'
         guest = DummyGuest(FakeContainer())
-        guest.add_ssh_pubkey_to_root_authorized_keys('pubkey')
+        guest.add_ssh_pubkey_to_authorized_keys('pubkey', '/root')
         assert guest.lxd_container.execute.call_count == 1
         assert guest.lxd_container.execute.call_args[0] == (['mkdir', '-p', '/root/.ssh'], )
         assert guest.lxd_container.files.put.call_count == 1

--- a/tests/unit/provisioners/test_ansible.py
+++ b/tests/unit/provisioners/test_ansible.py
@@ -48,7 +48,6 @@ class TestAnsibleProvisioner:
             ['apk', 'add', 'openssh'],
             ['rc-update', 'add', 'sshd'],
             ['/etc/init.d/sshd', 'start'],
-            ['mkdir', '-p', '/root/.ssh'],
         ]
         calls = [tup[0][0] for tup in lxd_container.execute.call_args_list]
         assert calls == EXPECTED


### PR DESCRIPTION
Previously, the SSH key from the host user was only installed in the authorized_keys file of the root user in the container. It only did that, if the ansible provisioner was used.

This path changes two thing:

* The key is always installed in the container, even without ansible being used
* The key is installed for all users created by lxdock, not just root

This fixes #167 
