### PR TITLE
Upgrade PyYAML, update upper limit from pinned version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'colorlog>=2.0,<3.0',
         'pylxd>=2.2.10',
         'python-dotenv>=0.6',
-        'PyYAML>=3.0,<4.0',
+        'PyYAML>=3.0,<6.0',
         'voluptuous>=0.9,<1.0',
     ],
     tests_require=[


### PR DESCRIPTION
At the time PyYAML 4.x hadn't been released yet, now we're upto 5.3

Have tested and can't see any breakages other than the existing breakages which seem pylxd related.

Thank you for contributing to LXDock! A list of simple rules is available on the online
documentation to help you contribute to this project: http://lxdock.readthedocs.io/en/latest/contributing.html.
Please review these guidelines before submitting your pull request!
