### PR TITLE
Correctly set the SHELL variable

### DIFF
--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -140,6 +140,7 @@ class Container:
             self._container.files.put(self._guest_shell_script_file, textwrap.dedent(
                 """\
                 #!/bin/sh
+                export SHELL=/bin/sh
                 {}
                 """.format(command)))
             self._guest.run(['chmod', 'a+rx', self._guest_shell_script_file])

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -146,7 +146,7 @@ class TestContainer(LXDTestCase):
                 persistent_container.lxd_name, persistent_container._guest_shell_script_file)
         script = persistent_container._container.files.get(
             persistent_container._guest_shell_script_file)
-        assert script == b"""#!/bin/sh\ncd /; ls -l\n"""
+        assert script == b"""#!/bin/sh\nexport SHELL=/bin/sh\ncd /; ls -l\n"""
 
     @unittest.mock.patch('subprocess.call')
     def test_can_run_shell_command_for_a_specific_shelluser(self, mocked_call):
@@ -162,7 +162,7 @@ class TestContainer(LXDTestCase):
             'lxc exec {} -- su -l test -s {}'.format(
                 container.lxd_name, container._guest_shell_script_file)
         script = container._container.files.get(container._guest_shell_script_file)
-        assert script == b"""#!/bin/sh\ncd /; ls -l\n"""
+        assert script == b"""#!/bin/sh\nexport SHELL=/bin/sh\ncd /; ls -l\n"""
 
     @unittest.mock.patch('subprocess.call')
     def test_can_set_shell_environment_variables(self, mocked_call):


### PR DESCRIPTION
Right now, since we are launching shell commands by first transferring a script and then launching the script as if it is a shell (see man su for the -s option), it sets the SHELL environment variable to the script.

Some applications relies on using the SHELL environment variable to launch subprocesses, which could result in a forkbomb. This PR fixes this behaviour by setting the SHELL to /bin/sh, which is accurate.

Based on original PR#153 by shuhaowu, checking to see if we get two failed tests agains latest master.

Thank you for contributing to LXDock! A list of simple rules is available on the online
documentation to help you contribute to this project: http://lxdock.readthedocs.io/en/latest/contributing.html.
Please review these guidelines before submitting your pull request!
