### PR TITLE
Fix pycodestyle issue that was undetected + typo

### DIFF
--- a/lxdock/container.py
+++ b/lxdock/container.py
@@ -420,8 +420,8 @@ class Container:
                 name = config.pop('name')
                 self._guest.create_user(name, **config)
                 if ssh_pubkey is not None:
-                    # Use the default home directory for the SSH key, unless explicitely configured
-                    home_dir = '/home/'+name
+                    # Use the default home directory for the SSH key, unless explicitly configured
+                    home_dir = '/home/' + name
                     if 'home' in config:
                         home_dir = config['home']
                     uid, gid = self._guest.uidgid(name)


### PR DESCRIPTION
Should have spacing around +, pycodestyle should have picked this up, not sure why it didn't.

Thank you for contributing to LXDock! A list of simple rules is available on the online
documentation to help you contribute to this project: http://lxdock.readthedocs.io/en/latest/contributing.html.
Please review these guidelines before submitting your pull request!
