### PR TITLE
Fix a whole bunch of typos in code, docs and tests

### DIFF
--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -5,7 +5,7 @@ Most of your interaction with LXDock will be done using the ``lxdock`` command. 
 many subcommands: ``up``, ``halt``, ``destroy``, etc. These subcommands are described in the
 following pages but you can easily get help using the ``help`` subcommand. ``lxdock help`` will
 display help information for the ``lxdock`` command while ``lxdock help [subcommand]`` will show the
-help for a specifc subcommand. For example:
+help for a specific subcommand. For example:
 
 .. code-block:: console
 

--- a/docs/cli/init.rst
+++ b/docs/cli/init.rst
@@ -11,7 +11,7 @@ Options
 
 * ``--image`` - this option allows to use a specific container image in the generated configuration
 * ``--project`` - this option allows to define the name of the project that will appear in the LXDock file
-* ``--force`` or ``-f`` - this option allows to overwrite an exsting LXDock file if any
+* ``--force`` or ``-f`` - this option allows to overwrite an existing LXDock file if any
 
 Examples
 --------

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -99,7 +99,7 @@ There are many scenarios to consider when you have to choose the value of the ``
 you choose to set your ``image`` option to ``ubuntu/xenial`` this means that the container will use
 the Ubuntu's Xenial version with the same architecture as your host machine (amd64 in most cases).
 It should be noted that the ``image`` value can also contain a container alias that includes the
-targetted architecture (eg. ``debian/jessie/amd64`` or ``ubuntu/xenial/armhf``).
+target architecture (eg. ``debian/jessie/amd64`` or ``ubuntu/xenial/armhf``).
 
 Here is an example:
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -83,8 +83,8 @@ You can easily get the code coverage of the project using the following command:
 
   $ make coverage
 
-Note: The tests will fail, if you have a `lydock.yml` file lying arund in your source directory.
-  
+Note: The tests will fail, if you have a `lxdock.yml` file lying around in your source directory.
+
 Test environment
 ################
 
@@ -106,8 +106,8 @@ You can delete the VM if you are done with::
 
   vagrant destroy
 
-Note: If you want to run tests on the host and in the VM, you need to run ``make clean`` everytime you switch system, since pycache files are incompatible.
-  
+Note: If you want to run tests on the host and in the VM, you need to run ``make clean`` every time you switch system, since pycache files are incompatible.
+
 Using the issue tracker
 -----------------------
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,7 +1,7 @@
 Glossary
 ========
 
-This is a comprehensive list of the terms used when discussing the functionalities and the
+This is a comprehensive list of the terms used when discussing the functionality and the
 configuration options of LXDock.
 
 .. glossary::

--- a/docs/provisioners/ansible.rst
+++ b/docs/provisioners/ansible.rst
@@ -4,8 +4,6 @@ Ansible
 
 LXDock provides built-in support for `Ansible`_ provisioning.
 
-.. _Ansible: https://www.ansible.com/
-
 Requirements
 ------------
 
@@ -83,7 +81,7 @@ This option is a hash of lists of container names. Example:
           - container2
         group2:
           - container2
-    
+
 lxd_transport
 =============
 

--- a/docs/provisioners/index.rst
+++ b/docs/provisioners/index.rst
@@ -18,8 +18,8 @@ defined in your LXDock file using the ``provisioning`` option:
 
   When using provisioners you should keep in mind that some of them can execute local actions on the
   host. For example Ansible playbooks can trigger local actions that will be run on your system.
-  Other provisioners (like the shell provisioner) can define commands to be runned on the host side
-  or in provileged containers. **You have to** trust the projects that use these provisioning tools
+  Other provisioners (like the shell provisioner) can define commands to be run on the host side
+  or in privileged containers. **You have to** trust the projects that use these provisioning tools
   before running LXDock!
 
 Documentation sections for the supported provisioning tools or methods are listed here.

--- a/docs/usage/provisioning.rst
+++ b/docs/usage/provisioning.rst
@@ -6,7 +6,7 @@ LXDock supports many provisioning tools in order to allow you to easily provisio
 using LXD. Using provisioning tools such as Ansible with LXDock will allow you to alter the
 configuration, install software, deploy applications and more on the containers. Using the built-in
 provisioning capabilities of LXDock will allow you to run these provisioning operations as part of
-the ``lxdock up`` wokflow. To be more precise, the provisioning tools associated with your LXDock
+the ``lxdock up`` workflow. To be more precise, the provisioning tools associated with your LXDock
 configuration are executed in the following situations:
 
 * when you run ``lxdock up`` the first time; that is when the container does not exist yet
@@ -31,7 +31,7 @@ playbook as follows:
       playbook: deploy/site.yml
 
 Note that you can use *many* provisioning tools. The order in which provisioning tools are defined
-in your LXdock file defines the order in which they are executed.
+in your LXDock file defines the order in which they are executed.
 
 .. note::
 

--- a/lxdock/cli/exceptions.py
+++ b/lxdock/cli/exceptions.py
@@ -1,5 +1,5 @@
 class CLIError(Exception):
-    """ An error occured during the processing of the CLI arguments. """
+    """ An error occurred during the processing of the CLI arguments. """
 
     def __init__(self, msg):
         self.msg = msg

--- a/lxdock/conf/exceptions.py
+++ b/lxdock/conf/exceptions.py
@@ -1,5 +1,5 @@
 class ConfigError(Exception):
-    """ An error related to the configuration of the LXDock project occured. """
+    """ An error related to the configuration of the LXDock project occurred. """
 
     def __init__(self, msg):
         self.msg = msg

--- a/lxdock/conf/validators.py
+++ b/lxdock/conf/validators.py
@@ -7,7 +7,10 @@ from voluptuous.validators import truth
 
 
 hostname_part_re = re.compile(r'(?!-)[A-Z\d-]{1,63}(?<!-)$', re.IGNORECASE)
-lxd_identifier_re = re.compile(r'^(([A-Z]|[A-Z][A-Z0-9\-]*[A-Z0-9])\.)*([A-Z]|[A-Z][A-Z0-9\-]*[A-Z0-9])$', re.IGNORECASE)  # noqa
+lxd_identifier_re = re.compile(
+    r'^(([A-Z]|[A-Z][A-Z0-9\-]*[A-Z0-9])\.)*([A-Z]|[A-Z][A-Z0-9\-]*[A-Z0-9])$',
+    re.IGNORECASE
+)
 
 
 @message('expected a valid hostname')
@@ -23,8 +26,8 @@ def Hostname(v):
 
 
 @message(
-    'expected a valid identifer no longer than 63 characters, starting with letters and made up of '
-    'letters, digits and dashes')
+    'expected a valid identifier no longer than 63 characters, starting with '
+    'letters and made up of letters, digits and dashes')
 @truth
 def LXDIdentifier(v):
     """ Validates an identifier that should obey to the same rules as RFC 952 hostnames. """

--- a/lxdock/exceptions.py
+++ b/lxdock/exceptions.py
@@ -4,7 +4,7 @@ class LXDockException(Exception):
 
 
 class ProjectError(LXDockException):
-    """ An error occured while excuting some action at the project level. """
+    """ An error occurred while executing some action at the project level. """
 
 
 class ContainerOperationFailed(LXDockException):

--- a/lxdock/guests/base.py
+++ b/lxdock/guests/base.py
@@ -71,7 +71,7 @@ class Guest(with_metaclass(_GuestBase)):
     `Guest` subclasses will be used by `Container` instances to perform common operations on the
     guest side. For example they can be used to ensure that some packages are installed when doing
     barebone setups, to create some users, ... `Guest` subclasses should correspond to specific OSes
-    or distributions that can be runned as LXD containers.
+    or distributions that can be run as LXD containers.
     """
 
     # The `name` of a guest is a required attribute and should always be set on `Guest` subclasses.

--- a/lxdock/hosts/base.py
+++ b/lxdock/hosts/base.py
@@ -67,8 +67,8 @@ class Host(with_metaclass(_HostBase)):
     """ Represents a single host.
 
     `Host` subclasses will be used by `Container` instances to perform common operations on the
-    host side. For example they can be used to retrieve some date (SSH pukeys, ...) or to set up
-    contaianers' hosts in the /etc/hosts file. `Host` subclasses should correspond to specific OSes
+    host side. For example they can be used to retrieve some date (SSH pubkeys, ...) or to set up
+    containers' hosts in the /etc/hosts file. `Host` subclasses should correspond to specific OSes
     or distributions that can be used to run LXD and LXDock.
     """
 

--- a/lxdock/network.py
+++ b/lxdock/network.py
@@ -5,7 +5,7 @@ import tempfile
 
 
 def get_ip(container):
-    """ Returns the IP adress of a specific container. """
+    """ Returns the IP address of a specific container. """
     state = container.state()
     if state.network is None:  # container is not running
         return ''

--- a/lxdock/utils/identifier.py
+++ b/lxdock/utils/identifier.py
@@ -2,6 +2,6 @@ import os
 
 
 def folderid(path):
-    """ Computes a unique identifer using a folder path. """
+    """ Computes a unique identifier using a folder path. """
     stats = os.stat(path)
     return str(stats.st_ino)

--- a/lxdock/utils/metaclass.py
+++ b/lxdock/utils/metaclass.py
@@ -18,7 +18,7 @@ def with_metaclass(meta, *bases):
     * if we are considering a subclass of the class to which the `with_metaclass` function was
       applied, the class being constructed will inherit from the `meta` metaclass
 
-    This trick is usefull to differentiate the class to which the `with_metaclass` function was
+    This trick is useful to differentiate the class to which the `with_metaclass` function was
     applied from its subclasses during the execution of the `__new__` magic method (which is defined
     inside the `meta` metaclass). This allows fine control over instances created with the `meta`
     metaclass.

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -339,7 +339,7 @@ class TestLXDock:
 
     @unittest.mock.patch('builtins.open')
     @unittest.mock.patch('os.getcwd')
-    def test_can_generate_a_lxdock_file_by_overwritting_an_existing_file_with_the_force_option(
+    def test_can_generate_a_lxdock_file_by_overwriting_an_existing_file_with_the_force_option(
             self, mock_getcwd, mock_open):
         mock_getcwd.return_value = os.path.join(FIXTURE_ROOT, 'project01')
         fd_mock = unittest.mock.Mock()

--- a/tests/unit/conf/test_config.py
+++ b/tests/unit/conf/test_config.py
@@ -98,7 +98,7 @@ class TestConfig:
         assert config['provisioning'][0]['inline'] == 'touch /opt/test01'
         assert config['provisioning'][1]['inline'] == 'echo $thisisatest'
 
-    def test_raises_an_error_if_a_variable_cannot_be_substituded(self):
+    def test_raises_an_error_if_a_variable_cannot_be_substituted(self):
         project_dir = os.path.join(FIXTURE_ROOT, 'project_with_dynamic_variables')
         with pytest.raises(ConfigFileInterpolationError):
             Config.from_base_dir(project_dir)


### PR DESCRIPTION
* Also linting of docs discovered that "_Ansible:" was there twice

Thank you for contributing to LXDock! A list of simple rules is available on the online
documentation to help you contribute to this project: http://lxdock.readthedocs.io/en/latest/contributing.html.
Please review these guidelines before submitting your pull request!
