### PR TITLE
Update uidmap documentation

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -275,12 +275,6 @@ of shared items. Each shared item should define a ``source`` (a path on your hos
   shares:
     - source: /path/to/my/workspace/project/
       dest: /myshare
-      set_host_acl: true
-
-.. note::
-
-  The ``set_host_acl`` parameter is optional and defaults to true when left out,
-  please refer to :doc:`usage/shared_folders` for more information.
 
 shell
 -----

--- a/lxdock/conf/schema.py
+++ b/lxdock/conf/schema.py
@@ -19,7 +19,6 @@ def get_schema():
         'shares': [{
             'source': ExpandUserIfExists,
             'dest': str,
-            'set_host_acl': bool,  # TODO: need a way to deprecate this
             'share_properties': {Extra: Coerce(str)},
         }],
         'shell': {


### PR DESCRIPTION
Update to the documentation how folders are shared. 
Fixes the 4th box of #122 

Questions for @robvdl to complete it:

There are two share related attributes defined in the schema: `set_host_acl` and `share_properties`. I couldn't figure out completely what they do (if anything at all).

`set_host_acl` appears to be deprecared, I couldn't find it in any python file.

`share_properties` is parsed in the `_setup_shares` method of  `lxdock/container.py`, but I think it is just some sort of passthrough to pylxd. What can you do with it?