### PR TITLE
Package lxdock as a snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,10 @@ env/
 
 # IDE/editor specific ignores
 .idea
+
+# Snap directories
+snap/
+parts/
+stage/
+prime/
+*.snap

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ upgrade:
 	pip install -e . -U
 
 lint:
-	flake8
+	flake8 --exclude snap,parts,stage,prime
 
 isort:
 	isort --check-only --recursive --diff lxdock tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-tests spec upgrade lint coverage isort travis docs clean
+.PHONY: install install-tests spec upgrade lint coverage isort travis docs clean snap
 
 install:
 	pip install -r requirements-dev.txt
@@ -28,6 +28,11 @@ travis: install-tests lint isort coverage
 
 docs:
 	cd docs && rm -rf _build && make html
+
+snap:
+	snapcraft clean lxdock -s pull
+	snapcraft
+	snapcraft clean lxdock -s pull
 
 clean:
 	find . -name '*.pyc' -exec rm -r {} \;

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -108,8 +108,8 @@ then LXD needs to be restarted.
 To restart LXD use ``sudo snap restart lxd`` or ``sudo service restart lxd``
 or equivalent for your system.
 
-Install LXDock
-~~~~~~~~~~~~~~
+Install LXDock via pip
+~~~~~~~~~~~~~~~~~~~~~~
 
 You should now be able to install LXDock using:
 
@@ -130,6 +130,33 @@ You should now be able to install LXDock using:
   Don't have ``pip3`` installed on your system? Most distros have a specific package for it, it's
   only a matter of installing it. For example, on Debian and Ubuntu, it's ``python3-pip``.
   Otherwise, `Stackoverflow can help you <http://stackoverflow.com/a/6587528>`__.
+
+Install LXDock via snap
+~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to build the snap package under Ubuntu, you need to install the
+`snapcraft` package first. You can then build by running
+
+.. code-block:: console
+
+  $ snapcraft
+
+The package file is then created in the local directory and you can install it
+with
+
+.. code-block:: console
+
+  $ sudo snap install lxdock_VERSION_amd64.snap --dangerous
+
+The `dangerous` flag is necessary, because you are installing a local package
+instead of a signed one downloaded from the official snap store.
+
+The executable can be found at ``/snap/bin/lxdock``. You might need to re-login
+or manually update your PATH environment variable.
+
+.. note::
+
+  Using lxdock from a snap package only works, if LXD itself is also installed via snap.
 
 Command line completion
 -----------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -9,7 +9,7 @@ Requirements
 * any provisioning tool you wish to use with LXDock
 
 .. _Python: https://www.python.org
-.. _LXD: https://www.ubuntu.com/cloud/lxd
+.. _LXD: https://linuxcontainers.org/lxd/
 
 Building LXDock on Linux
 ------------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -158,6 +158,9 @@ or manually update your PATH environment variable.
 
   Using lxdock from a snap package only works, if LXD itself is also installed via snap.
 
+  If you manually build the snap using ``snapcraft``, you should delete the directories
+  ``parts``, ``stage``, ``prime`` and ``snap`` afterwards, as they might interfere with the tests.
+
 Command line completion
 -----------------------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -139,7 +139,7 @@ In order to build the snap package under Ubuntu, you need to install the
 
 .. code-block:: console
 
-  $ snapcraft
+  $ make snap
 
 The package file is then created in the local directory and you can install it
 with

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -22,15 +22,15 @@ Prerequisite: install LXD
 You may want to skip this section if you already have a working installation
 of LXD on your system.
 
-LXD is available in the repository for Debian or Ubuntu 16.04 and higher:
+The official install method for LXD is via Snap which works on Ubuntu 14.04 and
+higher and is also available for `other distributions <https://snapcraft.io/docs/installing-snapd>`__.
+To install LXD from a Snap in Ubuntu:
 
 .. code-block:: console
 
-  $ sudo apt-get install lxd
-
-You can now also install LXD from Snap which works on Ubuntu 14.04 and higher.
-Since the LXD PPA has been deprecated, this is now the easiest way to get
-the latest version of LXD on Ubuntu.
+  $ sudo apt-get install snapd
+  $ sudo snap install lxd
+  $ sudo snap start lxd
 
 .. note::
 
@@ -43,15 +43,15 @@ the latest version of LXD on Ubuntu.
 
     $ sudo apt-get purge lxd lxd-client
 
-To install LXD from a Snap instead of apt:
+
+In older versions of Ubuntu (16.04 - 18.04) LXD is also available in the
+standard repository:
 
 .. code-block:: console
 
-  $ sudo apt-get install snapd
-  $ sudo snap install lxd
-  $ sudo snap start lxd
+  $ sudo apt-get install lxd
 
-For Fedora, LXD is available through an experimental COPR repository.
+For Fedora, LXD is also available through an experimental COPR repository.
 Unfortunately SELinux is not yet supported, therefore make sure it is
 disabled or set to permissive. Then run:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -4,7 +4,7 @@ Getting started
 Requirements
 ------------
 
-* `Python`_ 3.4+
+* `Python`_ 3.5+
 * `LXD`_ 2.0+
 * any provisioning tool you wish to use with LXDock
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: lxdock
+version: git
+summary: lxdock
+description: |
+  Build and orchestrate your development environments with LXD 
+  - a.k.a. Vagrant is Too Heavy
+base: core18
+confinement: strict
+
+parts:
+  lxdock:
+    plugin: python
+    python-version: python3
+    source: .
+    requirements: requirements-dev.txt
+apps:
+  lxdock:
+    command: bin/lxdock
+    plugs:
+      - lxd

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,7 +12,6 @@ parts:
     plugin: python
     python-version: python3
     source: .
-    requirements: requirements-dev.txt
 apps:
   lxdock:
     command: bin/lxdock


### PR DESCRIPTION
Instructions how to build a use a snap package of lxdock.

I also updated the *LXD installation* part of the documentation, to primarily suggest a snap based installation, since that is the official method Cannonical suggests and it also allows a more easy integration on other distributions than Ubuntu.

I would suggest to merge this as a first step as is, and later on adapt the Travis configuration to automatically build and publish an official package.

Fixes #156 