### PR TITLE
Disable pylxd warnings in CLI

### DIFF
--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -1,8 +1,36 @@
 Command-line reference
 ======================
 
-Most of your interaction with LXDock will be done using the ``lxdock`` command. This command provides
-many subcommands: ``up``, ``halt``, ``destroy``, etc. These subcommands are described in the
+Most of your interaction with LXDock will be done using the ``lxdock`` command.
+This command provides many subcommands:
+``up``, ``halt``, ``destroy``, etc.
+
+.. code-block:: console
+
+  $ lxdock --help
+  usage: lxdock [-h] [--version] [-v]
+              {config,destroy,halt,help,init,provision,shell,status,up} ...
+
+  Orchestrate and run multiple containers using LXD.
+
+  positional arguments:
+    {config,destroy,halt,help,init,provision,shell,status,up}
+      config              Validate and show the LXDock file.
+      destroy             Stop and remove containers.
+      halt                Stop containers.
+      help                Show help information.
+      init                Generate a LXDock file.
+      provision           Provision containers.
+      shell               Open a shell or execute a command in a container.
+      status              Show containers' statuses.
+      up                  Create, start and provision containers.
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    --version             show program's version number and exit
+    -v, --verbose
+
+The subcommands are described in the
 following pages but you can easily get help using the ``help`` subcommand. ``lxdock help`` will
 display help information for the ``lxdock`` command while ``lxdock help [subcommand]`` will show the
 help for a specific subcommand. For example:

--- a/lxdock/cli/main.py
+++ b/lxdock/cli/main.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 import sys
 
 from .. import __version__
@@ -125,6 +126,11 @@ class LXDock:
             console_stdout_handler.setLevel(logging.DEBUG)
         else:
             console_stdout_handler.setLevel(logging.INFO)
+            # Disable pylxd warning, unless a manual setting by the user exists
+            # For reference, see https://github.com/lxc/pylxd/pull/361 and
+            # https://github.com/lxc/pylxd/issues/301#issuecomment-383848200
+            if "PYLXD_WARNINGS" not in os.environ:
+                os.environ["PYLXD_WARNINGS"] = 'none'
 
         try:
             # use dispatch pattern to invoke method with same name

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -372,3 +372,42 @@ class TestLXDock:
         assert fd_mock.write.call_count == 1
         assert fd_mock.write.call_args[0][0] == INIT_LXDOCK_FILE_CONTENT.format(
             project_name='customproject', image='ubuntu/bionic')
+
+    @unittest.mock.patch.object(LXDock, 'help')
+    def test_main_function_disables_pylxd_warnings_without_verbose(self, mock_help_action):
+        _environ = os.environ.copy()
+        try:
+            os.environ.clear()
+            main(['help'])
+            assert "PYLXD_WARNINGS" in os.environ
+            assert os.environ["PYLXD_WARNINGS"] == 'none'
+        finally:
+            os.environ.clear()
+            os.environ.update(_environ)
+
+    @unittest.mock.patch.object(LXDock, 'help')
+    def test_main_function_not_disables_pylxd_warnings_with_verbose(self, mock_help_action):
+        _environ = os.environ.copy()
+        try:
+            os.environ.clear()
+            main(['--verbose', 'help'])
+            assert "PYLXD_WARNINGS" not in os.environ
+        finally:
+            os.environ.clear()
+            os.environ.update(_environ)
+
+    @unittest.mock.patch.object(LXDock, 'help')
+    def test_main_function_not_disables_pylxd_warnings_if_environemtvar_set(self, mock_help_action):
+        _environ = os.environ.copy()
+        try:
+            os.environ.clear()
+            os.environ["PYLXD_WARNINGS"] = 'foobar'
+            main(['--verbose', 'help'])
+            assert "PYLXD_WARNINGS" in os.environ
+            assert os.environ["PYLXD_WARNINGS"] == 'foobar'
+            main(['help'])
+            assert "PYLXD_WARNINGS" in os.environ
+            assert os.environ["PYLXD_WARNINGS"] == 'foobar'
+        finally:
+            os.environ.clear()
+            os.environ.update(_environ)


### PR DESCRIPTION
A patch to disable warnings coming from pylxd, if pylxd is up to date with the lxd installation on the system. The problem is explained here: https://github.com/lxc/pylxd/issues/301#issuecomment-383848200 , the upstream fix in pylxd was done here: https://github.com/lxc/pylxd/pull/361

The warnings are still shown, if either the `--verbose` switch is used to start `lxdock`, or the `PYLXD_WARNINGS` environment variable has been set to something (other than none) by the user. This behaviour should probably be documented, but I didn't find a good spot. Any suggestions?

I basically agree with [this comment](https://github.com/lxdock/lxdock/issues/146#issuecomment-389110717) by @tannoiser, that it might hide other problems. But since we cannot really control the system LXD installation (and also should not, since it might be used for other things than lxdock), I still think that this is the best solution.

Closes: #146 #171 